### PR TITLE
fix: 修复简历面试卡在"复盘生成中"无法恢复 (#27)

### DIFF
--- a/backend/routers/history.py
+++ b/backend/routers/history.py
@@ -5,7 +5,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from backend.auth import get_current_user
 from backend.runtime import _task_status
 from backend.storage.sessions import (
+    STATUS_REVIEW_FAILED,
+    STATUS_REVIEWED,
     delete_session,
+    expire_stale_reviewing,
     get_session,
     list_distinct_topics,
     list_sessions,
@@ -27,8 +30,20 @@ async def get_review(session_id: str, user_id: str = Depends(get_current_user)):
 
 @router.get("/tasks/{task_id}")
 async def get_task_status(task_id: str, user_id: str = Depends(get_current_user)):
-    """Poll async task status."""
+    """Poll async task status.
+
+    The in-memory task dict is lost on restart and never flips when a review
+    hangs, so when there's no live "done"/"error" to report we reconcile against
+    the persisted session — the source of truth — expiring stale reviews first.
+    """
     task = _task_status.get(task_id)
+    if not task or task.get("status") not in ("done", "error"):
+        expire_stale_reviewing(user_id=user_id)
+        session = get_session(task_id, user_id=user_id)
+        if session and session["status"] == STATUS_REVIEWED:
+            return {"task_id": task_id, "status": "done"}
+        if session and session["status"] == STATUS_REVIEW_FAILED:
+            return {"task_id": task_id, "status": "error", "result": session.get("review_error")}
     if not task:
         raise HTTPException(404, "Task not found.")
     return {"task_id": task_id, **task}
@@ -43,6 +58,7 @@ async def get_history(
     user_id: str = Depends(get_current_user),
 ):
     """List past interview sessions with filtering and pagination."""
+    expire_stale_reviewing(user_id=user_id)
     return list_sessions(user_id=user_id, limit=limit, offset=offset, mode=mode, topic=topic)
 
 

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -44,6 +44,7 @@ from backend.storage.sessions import (
     STATUS_REVIEWING,
     append_message,
     create_session,
+    expire_stale_reviewing,
     get_session,
     save_drill_answers,
     save_reference_answer,
@@ -632,6 +633,7 @@ async def get_session_for_resume(
     For resume-mode chats, also checks whether the LangGraph checkpoint can
     still drive another turn (can_continue=True ⇒ user can keep answering).
     """
+    expire_stale_reviewing(user_id=user_id)
     session = get_session(session_id, user_id=user_id)
     if not session:
         raise HTTPException(404, "Session not found.")

--- a/backend/storage/sessions.py
+++ b/backend/storage/sessions.py
@@ -16,6 +16,10 @@ STATUS_REVIEWING = "reviewing"      # review generation in-flight
 STATUS_REVIEWED = "reviewed"        # review persisted
 STATUS_REVIEW_FAILED = "review_failed"  # review attempt failed; user may retry
 
+# Reviews finish in well under a minute; a "reviewing" row older than this has a
+# hung or dead background task and must be recoverable without a server restart.
+STALE_REVIEW_SECONDS = 300
+
 
 def _get_conn() -> sqlite3.Connection:
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -124,6 +128,33 @@ def reset_stale_reviewing() -> int:
         "WHERE status = ?",
         (STATUS_REVIEW_FAILED, "服务重启导致复盘中断，请重新生成", STATUS_REVIEWING),
     )
+    conn.commit()
+    conn.close()
+    return cursor.rowcount
+
+
+def expire_stale_reviewing(*, user_id: str | None = None,
+                           max_age_seconds: int = STALE_REVIEW_SECONDS) -> int:
+    """Flip reviewing sessions stalled past the threshold to review_failed.
+
+    Runtime safety net for reviews whose background task hangs or whose process
+    died without startup recovery running — without it such sessions stay
+    "reviewing" forever. A task that finishes late still wins: save_review
+    overwrites the row back to reviewed. Returns count flipped.
+    """
+    conn = _get_conn()
+    sql = (
+        "UPDATE sessions SET status = ?, review_error = ?, updated_at = CURRENT_TIMESTAMP "
+        "WHERE status = ? AND updated_at < datetime('now', ?)"
+    )
+    params: list = [
+        STATUS_REVIEW_FAILED, "复盘生成超时，请重新生成",
+        STATUS_REVIEWING, f"-{int(max_age_seconds)} seconds",
+    ]
+    if user_id is not None:
+        sql += " AND user_id = ?"
+        params.append(user_id)
+    cursor = conn.execute(sql, params)
     conn.commit()
     conn.close()
     return cursor.rowcount

--- a/frontend/src/pages/Interview.jsx
+++ b/frontend/src/pages/Interview.jsx
@@ -194,7 +194,9 @@ export default function Interview() {
           });
         },
         onDone: (data) => {
-          if (data.is_finished) setFinished(true);
+          // Interview ended on its own (max rounds) — kick off review immediately
+          // so the user never lands on a finished chat with no review running.
+          if (data.is_finished) finishAndReview();
         },
         onError: (err) => {
           setMessages((prev) => {
@@ -213,7 +215,7 @@ export default function Interview() {
           updated[updated.length - 1] = { role: "assistant", content: data.message };
           return updated;
         });
-        if (data.is_finished) setFinished(true);
+        if (data.is_finished) finishAndReview();
       } catch (err) {
         setMessages((prev) => {
           const updated = [...prev];
@@ -227,16 +229,34 @@ export default function Interview() {
     }
   };
 
+  const startResumeReview = async () => {
+    await endInterview(sessionId);
+    setFinished(true);
+    setSessionStatus("reviewing");
+    setResumeError("");
+    startTask(sessionId, "resume_review", "简历面试复盘生成中");
+  };
+
   const handleEndResume = async () => {
     setReviewing(true);
     try {
-      await endInterview(sessionId);
-      setFinished(true);
-      setSessionStatus("reviewing");
-      setResumeError("");
-      startTask(sessionId, "resume_review", "简历面试复盘生成中");
+      await startResumeReview();
     } catch (err) {
       alert("结束面试失败: " + err.message);
+    } finally {
+      setReviewing(false);
+    }
+  };
+
+  // Auto-end path: interview finished on its own. Lock the chat regardless, then
+  // dispatch the review; on failure the "生成复盘" button lets the user retry.
+  const finishAndReview = async () => {
+    setFinished(true);
+    setReviewing(true);
+    try {
+      await startResumeReview();
+    } catch {
+      // Surfaced via the manual "生成复盘" button.
     } finally {
       setReviewing(false);
     }
@@ -511,7 +531,13 @@ export default function Interview() {
           const task = tasks.find((t) => t.id === sessionId);
           const taskDone = task?.status === "done" || sessionStatus === "reviewed";
           const taskError = task?.status === "error" || sessionStatus === "review_failed";
-          // Four branches: live chat → end, review failed → retry, review in-flight → wait, review done → view.
+          // A review is genuinely running only while a task is being polled or the
+          // server reports "reviewing". A finished chat without one means review was
+          // never dispatched (e.g. auto-ended on max rounds) — offer to generate it
+          // rather than show a dead "generating..." label.
+          const reviewInFlight =
+            (task && task.status !== "done" && task.status !== "error") ||
+            sessionStatus === "reviewing";
           let handler;
           let label;
           if (taskDone) {
@@ -520,12 +546,15 @@ export default function Interview() {
           } else if (taskError) {
             handler = handleRetryResumeReview;
             label = reviewing ? "重新生成中..." : "重新生成复盘";
+          } else if (reviewInFlight) {
+            handler = undefined;
+            label = "复盘生成中...";
           } else if (!finished) {
             handler = handleEndResume;
             label = reviewing ? "生成复盘中..." : "结束面试";
           } else {
-            handler = undefined;
-            label = "复盘生成中...";
+            handler = handleEndResume;
+            label = reviewing ? "生成复盘中..." : "生成复盘";
           }
           return (
             <Button


### PR DESCRIPTION
Closes #27

## 问题
简历面试有两种情况会永久卡在"复盘生成中":
1. 对话到上限**自动结束**时,后端只返回 `is_finished`、不派发复盘(状态仍是 `ongoing`),前端却显示不可点的"复盘生成中...",复盘其实从没启动。重开记录依旧是这个死结。
2. 复盘任务**挂死/掉线**后状态停在 `reviewing`,目前只有重启服务(`reset_stale_reviewing`)才会恢复。

用户期望的"重新生成按钮 + 失败提示"其实早已实现(`review_failed` 状态的横幅和重试按钮),只是**走不到那个状态**。

## 改动
**前端 `Interview.jsx`**
- 自动结束(`is_finished`)时立即派发复盘,不再停在没有任务的 finished 状态。
- 按钮新增 `reviewInFlight` 判断:只有任务在轮询或服务端 `reviewing` 才显示不可点的"复盘生成中...";已结束但未派发复盘时显示**可点的"生成复盘"**。

**后端**
- `expire_stale_reviewing()`:运行期把超时(5min)的 `reviewing` 翻成 `review_failed`,晚到的任务仍会用 `save_review` 覆盖回 `reviewed`。
- `/tasks/{id}` 轮询以 DB 为准对账(内存任务丢失/挂死时按持久化状态返回);列表与重开会话前先 expire。

## 验证
- 后端 import / AST 通过;前端 eslint 0 error。