### PR TITLE
fix: 优化 _save_profile 原子写入，避免产生损坏的 profile.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-# 冒烟检查:每次 push / PR 时,在干净环境装依赖并尝试构建后端 app。
-# 目的是拦下"本地能跑、干净环境装不起来"的问题(如漏写依赖),让它到不了用户手里。
+# 后端检查:每次 push / PR 时,在干净环境安装依赖、构建 app 并运行回归测试。
+# 目的是拦下"本地能跑、干净环境装不起来"和已修问题回归,让它到不了用户手里。
 name: CI
 
 on:
@@ -23,6 +23,9 @@ jobs:
       - name: 构建后端 app(导入整棵依赖树 + 装配路由)
         run: |
           python -c "from backend.app import create_app; create_app(); print('OK app builds')"
+
+      - name: 运行后端回归测试
+        run: python -m unittest discover -s tests
 
   frontend-build:
     runs-on: ubuntu-latest

--- a/backend/memory.py
+++ b/backend/memory.py
@@ -11,6 +11,8 @@ import json
 import logging
 import math
 import re
+import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -249,10 +251,38 @@ def _save_profile(profile: dict, user_id: str):
     path = _profile_path(user_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     profile["updated_at"] = datetime.now().isoformat()
-    path.write_text(
-        json.dumps(profile, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+
+    temp_path = None
+    try:
+        # 临时文件必须和目标文件位于同一目录，确保 os.replace 是原子的
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+
+            json.dump(
+                profile,
+                temp_file,
+                ensure_ascii=False,
+                indent=2,
+            )
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+
+        # Windows 下必须先关闭临时文件，再替换目标文件
+        os.replace(temp_path, path)
+        temp_path = None  # 成功后置空
+
+    finally:
+        # 替换失败时清理临时文件；成功时文件已不存在
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
 
 
 def _save_insight(mode: str, topic: str, summary: str, raw_extraction: dict, user_id: str):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -11,11 +11,66 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi import BackgroundTasks, HTTPException
 
+from backend import memory
 from backend.config import settings
 from backend.routers import copilot, data_migration as migration_router, interview, recording
 from backend.runtime import _task_status
 from backend.storage import data_migration, sessions
 from backend.utils import safe_child_path
+
+
+class ProfilePersistenceTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.profile_path = Path(self.temp_dir.name) / "profile.json"
+        self.path_patch = patch.object(
+            memory, "_profile_path", return_value=self.profile_path
+        )
+        self.path_patch.start()
+
+    def tearDown(self):
+        self.path_patch.stop()
+        self.temp_dir.cleanup()
+
+    def _temporary_files(self):
+        return list(self.profile_path.parent.glob(f".{self.profile_path.name}.*.tmp"))
+
+    def _write_existing_profile(self):
+        original = json.dumps(
+            {"name": "existing", "updated_at": "before"},
+            ensure_ascii=False,
+        ).encode()
+        self.profile_path.write_bytes(original)
+        return original
+
+    def test_save_profile_replaces_file_with_valid_json(self):
+        profile = {"name": "new profile"}
+
+        memory._save_profile(profile, "user-a")
+
+        saved = json.loads(self.profile_path.read_text(encoding="utf-8"))
+        self.assertEqual(saved, profile)
+        self.assertTrue(saved["updated_at"])
+        self.assertEqual(self._temporary_files(), [])
+
+    def test_serialization_failure_keeps_existing_profile_and_cleans_temp_file(self):
+        original = self._write_existing_profile()
+
+        with self.assertRaises(TypeError):
+            memory._save_profile({"not_json": object()}, "user-a")
+
+        self.assertEqual(self.profile_path.read_bytes(), original)
+        self.assertEqual(self._temporary_files(), [])
+
+    def test_replace_failure_keeps_existing_profile_and_cleans_temp_file(self):
+        original = self._write_existing_profile()
+
+        with patch.object(memory.os, "replace", side_effect=OSError("replace failed")):
+            with self.assertRaisesRegex(OSError, "replace failed"):
+                memory._save_profile({"name": "new profile"}, "user-a")
+
+        self.assertEqual(self.profile_path.read_bytes(), original)
+        self.assertEqual(self._temporary_files(), [])
 
 
 class DataExportIsolationTests(unittest.TestCase):


### PR DESCRIPTION
## 改动说明
优化 `_save_profile` 用户配置持久化逻辑，实现跨平台原子写入。
当程序意外终止、崩溃时，不会生成半截损坏、无法解析的 profile.json。

主要改进：
1. 使用同目录临时文件 + os.replace() 原子替换
2. flush + fsync 强制落盘，降低断电损坏风险
3. 兼容 Windows 文件句柄占用问题
4. finally 自动清理残留临时 .tmp 文件

全部使用 Python 标准库，不新增任何第三方依赖。