### PR TITLE
Raise nginx upload limit

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    client_max_body_size 500m;
 
     location / {
         root /usr/share/nginx/html;


### PR DESCRIPTION
## What changed

- Set `client_max_body_size 500m` in the frontend nginx server configuration.

## Why

The frontend nginx container used the default 1 MB request-body limit, so resume uploads larger than 1 MB were rejected with HTTP 413 before reaching FastAPI. The public nginx entry point already permits 500 MB, and the application supports uploads up to that size for data imports.

## Impact

Uploads can now reach the backend, where endpoint-specific validation and size limits remain authoritative.

## Validation

- Rebuilt the frontend Docker image successfully.
- `nginx -t` passed in the deployed frontend container.
- Confirmed the running configuration contains `client_max_body_size 500m`.
- Sent a 2 MB request through `https://techspar.top`; it reached backend authentication and returned 401 instead of nginx 413.
