### PR TITLE
Fix embedding provider input compatibility

### DIFF
--- a/backend/llm_provider.py
+++ b/backend/llm_provider.py
@@ -10,6 +10,8 @@ backends (esp. local HuggingFace models) are expensive, so they are cached per
 (user, config-signature) and rebuilt only when the signature changes.
 """
 
+import logging
+
 from langchain_openai import ChatOpenAI
 
 from backend.config import (
@@ -26,6 +28,8 @@ from backend.user_context import get_current_user_id
 
 # user_key ("__global__" or user_id) → (signature, embed_instance)
 _embedding_cache: dict[str, tuple[str, object]] = {}
+
+logger = logging.getLogger("uvicorn")
 
 _DEFAULT_TEMPERATURE = 0.7
 _COPILOT_TEMPERATURE = 0.3  # Copilot 场景偏确定性
@@ -141,7 +145,14 @@ def get_copilot_llm(user_id: str | None = None, streaming: bool = False):
 class _APIEmbedding:
     """OpenAI-compatible embedding client. Exposes the minimal interface the rest of
     the codebase relies on (get_text_embedding / get_text_embedding_batch). Batches to
-    `batch_size` to respect per-request limits, which vary by provider."""
+    `batch_size` to respect per-request limits, which vary by provider.
+
+    Some otherwise OpenAI-compatible providers (notably ModelScope API-Inference)
+    accept only a scalar string for ``input``. Prefer efficient array requests, but
+    learn and remember a scalar-only capability after a 400 response and a successful
+    scalar retry. This also safely handles providers whose effective batch limit is
+    lower than the configured value.
+    """
 
     def __init__(self, model: str, api_key: str, api_base: str, batch_size: int):
         from openai import OpenAI
@@ -149,15 +160,53 @@ class _APIEmbedding:
         self._client = OpenAI(api_key=api_key, base_url=api_base or None)
         self._model = model
         self._batch = max(1, batch_size)
+        self._array_input_supported: bool | None = None
+
+    def _request(self, value: str | list[str], expected_count: int) -> list[list[float]]:
+        resp = self._client.embeddings.create(model=self._model, input=value)
+        data = list(resp.data)
+        if data and all(isinstance(getattr(item, "index", None), int) for item in data):
+            data.sort(key=lambda item: item.index)
+        vectors = [item.embedding for item in data]
+        if len(vectors) != expected_count:
+            raise RuntimeError(
+                f"Embedding provider returned {len(vectors)} vectors for "
+                f"{expected_count} inputs"
+            )
+        return vectors
 
     def get_text_embedding(self, text: str) -> list[float]:
-        return self.get_text_embedding_batch([text])[0]
+        # A scalar input is accepted by both the OpenAI API and scalar-only compatible
+        # providers, so single-text call sites do not need capability negotiation.
+        return self._request(text, 1)[0]
 
     def get_text_embedding_batch(self, texts: list[str]) -> list[list[float]]:
         out: list[list[float]] = []
         for i in range(0, len(texts), self._batch):
-            resp = self._client.embeddings.create(model=self._model, input=texts[i:i + self._batch])
-            out.extend(d.embedding for d in resp.data)
+            batch = texts[i:i + self._batch]
+            if self._array_input_supported is False:
+                out.extend(self._request(text, 1)[0] for text in batch)
+                continue
+
+            try:
+                out.extend(self._request(batch, len(batch)))
+                self._array_input_supported = True
+            except Exception as exc:
+                # Authentication, throttling and service failures must surface as-is.
+                # Only a provider-declared bad request can indicate an unsupported
+                # array shape or a stricter batch limit.
+                if getattr(exc, "status_code", None) != 400:
+                    raise
+
+                first = self._request(batch[0], 1)[0]
+                self._array_input_supported = False
+                logger.warning(
+                    "Embedding provider rejected array input; falling back to "
+                    "scalar requests for model %s.",
+                    self._model,
+                )
+                out.append(first)
+                out.extend(self._request(text, 1)[0] for text in batch[1:])
         return out
 
 
@@ -266,7 +315,9 @@ def probe_embedding(config: dict) -> None:
 
         client = OpenAI(api_key=config["api_key"], base_url=config["api_base"] or None,
                         timeout=20.0, max_retries=0)
-        client.embeddings.create(model=model_name, input=["ping"])
+        # Scalar input is the common denominator across OpenAI-compatible embedding
+        # services; runtime batch calls negotiate array support independently.
+        client.embeddings.create(model=model_name, input="ping")
         return
     _build_embedding(config).get_text_embedding("ping")
 

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,133 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from backend import llm_provider
+
+
+class _ProviderError(RuntimeError):
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        super().__init__(f"provider returned {status_code}")
+
+
+class _FakeEmbeddings:
+    def __init__(self, create):
+        self.create = create
+
+
+class _FakeOpenAI:
+    def __init__(self, create):
+        self.embeddings = _FakeEmbeddings(create)
+
+
+def _response(*vectors):
+    return SimpleNamespace(
+        data=[
+            SimpleNamespace(index=index, embedding=vector)
+            for index, vector in enumerate(vectors)
+        ]
+    )
+
+
+class APIEmbeddingCompatibilityTests(unittest.TestCase):
+    @staticmethod
+    def _embedding(create, *, batch_size=10):
+        with patch("openai.OpenAI", return_value=_FakeOpenAI(create)):
+            return llm_provider._APIEmbedding(
+                model="test-embedding",
+                api_key="test-key",
+                api_base="https://example.test/v1",
+                batch_size=batch_size,
+            )
+
+    def test_batch_capable_provider_keeps_using_array_input(self):
+        calls = []
+
+        def create(*, model, input):
+            calls.append((model, input))
+            return _response(*[[float(len(text))] for text in input])
+
+        embedding = self._embedding(create, batch_size=2)
+
+        result = embedding.get_text_embedding_batch(["a", "bb", "ccc"])
+
+        self.assertEqual(result, [[1.0], [2.0], [3.0]])
+        self.assertEqual(
+            calls,
+            [
+                ("test-embedding", ["a", "bb"]),
+                ("test-embedding", ["ccc"]),
+            ],
+        )
+
+    def test_bad_array_request_falls_back_to_scalar_and_remembers_capability(self):
+        calls = []
+
+        def create(*, model, input):
+            calls.append(input)
+            if isinstance(input, list):
+                raise _ProviderError(400)
+            return _response([float(len(input))])
+
+        embedding = self._embedding(create)
+
+        first = embedding.get_text_embedding_batch(["a", "bb", "ccc"])
+        second = embedding.get_text_embedding_batch(["dddd", "eeeee"])
+
+        self.assertEqual(first, [[1.0], [2.0], [3.0]])
+        self.assertEqual(second, [[4.0], [5.0]])
+        self.assertEqual(calls, [["a", "bb", "ccc"], "a", "bb", "ccc", "dddd", "eeeee"])
+
+    def test_non_bad_request_error_does_not_retry_or_hide_failure(self):
+        calls = []
+
+        def create(*, model, input):
+            calls.append(input)
+            raise _ProviderError(503)
+
+        embedding = self._embedding(create)
+
+        with self.assertRaisesRegex(_ProviderError, "503"):
+            embedding.get_text_embedding_batch(["a", "b"])
+
+        self.assertEqual(calls, [["a", "b"]])
+
+    def test_single_text_call_uses_scalar_input(self):
+        calls = []
+
+        def create(*, model, input):
+            calls.append(input)
+            return _response([1.0, 2.0])
+
+        embedding = self._embedding(create)
+
+        self.assertEqual(embedding.get_text_embedding("ping"), [1.0, 2.0])
+        self.assertEqual(calls, ["ping"])
+
+
+class EmbeddingProbeCompatibilityTests(unittest.TestCase):
+    def test_api_probe_uses_scalar_input(self):
+        calls = []
+
+        def create(*, model, input):
+            calls.append((model, input))
+            return _response([1.0])
+
+        config = {
+            "backend": "api",
+            "api_base": "https://example.test/v1",
+            "api_key": "test-key",
+            "api_model": "test-embedding",
+            "local_model": "",
+            "local_path": "",
+            "api_batch_size": 10,
+        }
+        with patch("openai.OpenAI", return_value=_FakeOpenAI(create)):
+            llm_provider.probe_embedding(config)
+
+        self.assertEqual(calls, [("test-embedding", "ping")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- negotiate array-input support for OpenAI-compatible embedding providers and fall back to scalar requests after a provider-declared `400` plus a successful scalar retry
- remember scalar-only capability for the client lifetime while preserving efficient batching for providers that support arrays
- use scalar input for single-text embeddings and the Settings connection probe
- validate response vector counts and add focused provider-compatibility regression coverage

## Root cause

Some otherwise OpenAI-compatible embedding services, including ModelScope API-Inference for `Qwen/Qwen3-Embedding-8B`, accept a scalar string but reject the array input used during resume ingestion. The rejection surfaced as `400 / 20015` and prevented resume interviews from starting.

## Impact

Resume, knowledge-base, and memory indexing can now work with scalar-only embedding providers without provider-specific hard-coding. Authentication, throttling, and service errors are still surfaced instead of being hidden by fallback behavior.

## Validation

- `python -m unittest discover -s tests -v` — 29 passed
- `git diff --check origin/main...HEAD`

No real user API key was sent during validation.
