### PR TITLE
fix(简历编辑器): 修复侧边栏配置面板被压缩

### DIFF
--- a/frontend/src/resume/editor/SidePanel.tsx
+++ b/frontend/src/resume/editor/SidePanel.tsx
@@ -161,7 +161,7 @@ export function SidePanel({
   return (
     <motion.div
       className={cn(
-        "w-[80]  overflow-y-auto",
+        "w-full overflow-y-auto",
         "bg-background border-border"
       )}
       initial={{ x: -100, opacity: 0 }}


### PR DESCRIPTION
原来:
<img width="3044" height="1238" alt="image" src="https://github.com/user-attachments/assets/d32a0de2-ef0e-4113-bdd6-b50c9516deb3" />

修复后:
<img width="3418" height="1203" alt="image" src="https://github.com/user-attachments/assets/53fe5608-2927-4c61-9a2a-7e68ae2068b1" />
