### PR TITLE
fix(embedding): 兼容完整端点作为 Base URL

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -167,7 +167,7 @@ DEFAULT_NAME=admin
 ALLOW_REGISTRATION=false
 ```
 
-Every model and service key is **per-user**, entered in **Settings** after login. A two-step first-login wizard walks you through **LLM + Embedding** (Embedding is required — it vectorizes resume / knowledge base / memory):
+Every model and service key is **per-user**, entered in **Settings** after login. A two-step first-login wizard walks you through **LLM + Embedding** (Embedding is required for knowledge bases, personal documents, and memory; resumes are read in full):
 
 - **LLM**: any OpenAI-compatible endpoint (API Base + Key + Model).
 - **Embedding**: `api` mode via a compatible endpoint, or `local` mode with a local HuggingFace model (needs `pip install -r requirements.local-embedding.txt`).
@@ -175,7 +175,7 @@ Every model and service key is **per-user**, entered in **Settings** after login
 No keys? You can run it for free (both providers offer free quota, and they can differ):
 
 - Main LLM: ModelScope `ZhipuAI/GLM-5`, base `https://api-inference.modelscope.cn/v1`, key = ModelScope SDK Token (<https://modelscope.cn/home>)
-- Embedding: SiliconFlow `BAAI/bge-large-zh-v1.5`, base `https://api.siliconflow.cn/v1`, key = SiliconFlow API Key (<https://cloud.siliconflow.cn/>)
+- Embedding: SiliconFlow `BAAI/bge-large-zh-v1.5`, base `https://api.siliconflow.cn/v1`, key = SiliconFlow API Key (<https://cloud.siliconflow.cn/>). If you paste the full `.../v1/embeddings` endpoint from provider documentation, TechSpar automatically normalizes it to the base URL.
 
 **Optional services** are also per-user, filled under **Settings → Optional Services / Voiceprint** as needed (left blank = that feature stays off):
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ cp .env.example .env
 没有 key 也能零成本跑通，免费示例（两家都有免费额度，可分开用）：
 
 - 主 LLM：ModelScope 的 `ZhipuAI/GLM-5`，Base `https://api-inference.modelscope.cn/v1`，Key 填 ModelScope SDK Token（<https://modelscope.cn/home>）
-- Embedding：SiliconFlow 的 `BAAI/bge-large-zh-v1.5`，Base `https://api.siliconflow.cn/v1`，Key 填 SiliconFlow API Key（<https://cloud.siliconflow.cn/>）
+- Embedding：SiliconFlow 的 `BAAI/bge-large-zh-v1.5`，Base `https://api.siliconflow.cn/v1`，Key 填 SiliconFlow API Key（<https://cloud.siliconflow.cn/>）。如果从服务商文档复制了完整的 `.../v1/embeddings` 地址，系统会自动转换为 Base URL。
 
 认证默认值如下，不配置也能启动：
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -12,6 +12,22 @@ DEFAULT_API_EMBED_BATCH_SIZE = 10
 # Free functions so both the global Settings object and per-user resolved
 # configs compute backend/model/path identically.
 
+def normalize_embedding_api_base(api_base: str) -> str:
+    """Accept an API base or a copied full ``/embeddings`` endpoint.
+
+    OpenAI-compatible clients append ``/embeddings`` themselves. Provider docs
+    commonly show the complete request URL, so treating that URL as the base
+    would otherwise produce ``.../embeddings/embeddings``.
+    """
+    value = api_base.strip().rstrip("/")
+    suffix = "/embeddings"
+    if value.lower().endswith(suffix):
+        base = value[:-len(suffix)].rstrip("/")
+        if base:
+            return base
+    return value
+
+
 def embedding_mode_of(backend: str, api_base: str, api_key: str) -> str:
     if backend:
         b = backend.strip().lower()

--- a/backend/llm_provider.py
+++ b/backend/llm_provider.py
@@ -22,6 +22,7 @@ from backend.config import (
     embedding_local_path_of,
     embedding_mode_of,
     embedding_target_of,
+    normalize_embedding_api_base,
     settings,
 )
 from backend.storage.user_settings import load_user_provider, load_user_services
@@ -197,7 +198,8 @@ class _APIEmbedding:
     def __init__(self, model: str, api_key: str, api_base: str, batch_size: int):
         from openai import OpenAI
 
-        self._client = OpenAI(api_key=api_key, base_url=api_base or None)
+        normalized_base = normalize_embedding_api_base(api_base)
+        self._client = OpenAI(api_key=api_key, base_url=normalized_base or None)
         self._model = model
         self._batch = max(1, batch_size)
         self._array_input_supported: bool | None = None
@@ -353,7 +355,8 @@ def probe_embedding(config: dict) -> None:
             raise RuntimeError("Embedding Model 必填")
         from openai import OpenAI
 
-        client = OpenAI(api_key=config["api_key"], base_url=config["api_base"] or None,
+        normalized_base = normalize_embedding_api_base(config["api_base"])
+        client = OpenAI(api_key=config["api_key"], base_url=normalized_base or None,
                         timeout=20.0, max_retries=0)
         # Scalar input is the common denominator across OpenAI-compatible embedding
         # services; runtime batch calls negotiate array support independently.

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from enum import Enum
 from typing import Literal, TypedDict
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
-from backend.config import DEFAULT_API_EMBED_BATCH_SIZE
+from backend.config import DEFAULT_API_EMBED_BATCH_SIZE, normalize_embedding_api_base
 
 
 # ── Enums ──
@@ -187,6 +187,13 @@ class EmbeddingSettings(BaseModel):
     local_path: str = ""
     # API 单批文本数上限,因服务商而异(如 DashScope 10、OpenAI 上千)。默认保守取小值;仅 API 模式生效。
     api_batch_size: int = Field(default=DEFAULT_API_EMBED_BATCH_SIZE, ge=1, le=2048)
+
+    @field_validator("api_base", mode="before")
+    @classmethod
+    def normalize_api_base(cls, value: object) -> object:
+        if isinstance(value, str):
+            return normalize_embedding_api_base(value)
+        return value
 
 
 class ServiceSettings(BaseModel):

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,7 +37,7 @@ EMBEDDING_API_MODEL=your-embedding-model
 * `API_KEY`：上面这个 LLM 接口的密钥。
 * `MODEL`：主 LLM 模型名。
 * `EMBEDDING_BACKEND`：Embedding 走哪条路，只能是 `api` 或 `local`。
-* `EMBEDDING_API_BASE`：Embedding 接口地址。如果你用官方 OpenAI Embedding，这个值可以留空。
+* `EMBEDDING_API_BASE`：Embedding 的 Base URL，通常填到 `/v1`。如果粘贴了完整的 `.../v1/embeddings` 地址，系统会自动转换；如果你用官方 OpenAI Embedding，这个值可以留空。
 * `EMBEDDING_API_KEY`：Embedding 接口密钥。
 * `EMBEDDING_API_MODEL`：Embedding 模型名。这里不要照抄示例，应该改成你的服务实际支持的模型。
 

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -3,6 +3,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from backend import llm_provider
+from backend.config import normalize_embedding_api_base
+from backend.models import EmbeddingSettings
 
 
 class _ProviderError(RuntimeError):
@@ -105,6 +107,46 @@ class APIEmbeddingCompatibilityTests(unittest.TestCase):
         self.assertEqual(embedding.get_text_embedding("ping"), [1.0, 2.0])
         self.assertEqual(calls, ["ping"])
 
+    def test_runtime_accepts_full_embeddings_endpoint_as_base_url(self):
+        client = _FakeOpenAI(lambda **_: _response([1.0]))
+
+        with patch("openai.OpenAI", return_value=client) as factory:
+            llm_provider._APIEmbedding(
+                model="test-embedding",
+                api_key="test-key",
+                api_base="https://example.test/v1/embeddings/",
+                batch_size=10,
+            )
+
+        factory.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://example.test/v1",
+        )
+
+
+class EmbeddingBaseURLCompatibilityTests(unittest.TestCase):
+    def test_normalizer_preserves_base_and_accepts_full_endpoint(self):
+        cases = {
+            "https://example.test/v1": "https://example.test/v1",
+            "https://example.test/v1/": "https://example.test/v1",
+            "https://example.test/v1/embeddings": "https://example.test/v1",
+            "https://example.test/v1/embeddings/": "https://example.test/v1",
+        }
+
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(normalize_embedding_api_base(value), expected)
+
+    def test_settings_store_canonical_api_base(self):
+        config = EmbeddingSettings(
+            backend="api",
+            api_base="https://example.test/v1/embeddings/",
+            api_key="test-key",
+            api_model="test-embedding",
+        )
+
+        self.assertEqual(config.api_base, "https://example.test/v1")
+
 
 class EmbeddingProbeCompatibilityTests(unittest.TestCase):
     def test_api_probe_uses_scalar_input(self):
@@ -116,17 +158,23 @@ class EmbeddingProbeCompatibilityTests(unittest.TestCase):
 
         config = {
             "backend": "api",
-            "api_base": "https://example.test/v1",
+            "api_base": "https://example.test/v1/embeddings",
             "api_key": "test-key",
             "api_model": "test-embedding",
             "local_model": "",
             "local_path": "",
             "api_batch_size": 10,
         }
-        with patch("openai.OpenAI", return_value=_FakeOpenAI(create)):
+        with patch("openai.OpenAI", return_value=_FakeOpenAI(create)) as factory:
             llm_provider.probe_embedding(config)
 
         self.assertEqual(calls, [("test-embedding", "ping")])
+        factory.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://example.test/v1",
+            timeout=20.0,
+            max_retries=0,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题

用户从 SiliconFlow 等服务商文档复制完整的 `/v1/embeddings` 请求地址后，OpenAI 兼容客户端还会再追加一次 `/embeddings`，最终请求到重复路径并返回 404。

## 修改

- 将末尾的 `/embeddings` 或 `/embeddings/` 统一规范化为真正的 API Base URL
- 让设置保存、连接测试和实际 Embedding 调用共用同一规则
- 补充运行时、探测与设置模型的回归测试
- 同步中英文 README 和部署说明

用户仍可填写标准的 `https://api.siliconflow.cn/v1`，也可以直接粘贴完整的 `https://api.siliconflow.cn/v1/embeddings`。

## 验证

- Embedding 聚焦测试：8/8 通过
- 后端完整测试：42/42 通过
- 前端 `npm run typecheck` 通过
- 前端 `npm run lint` 通过（0 error，只有既有 warning）
- 前端 `npm run build` 通过
- `git diff --check` 通过

Fixes #53
