### PR TITLE
fix(resume): normalize stored PDF bytes

### DIFF
--- a/packages/platform/src/resume-store.ts
+++ b/packages/platform/src/resume-store.ts
@@ -39,7 +39,7 @@ export class FileResumeStore implements ResumeStore {
   async read(userId: string): Promise<ResumeFile | undefined> {
     const filename = await this.find(userId)
     if (!filename) return undefined
-    return { filename, bytes: await readFile(join(this.directory(userId), filename)) }
+    return { filename, bytes: new Uint8Array(await readFile(join(this.directory(userId), filename))) }
   }
 
   async replace(userId: string, filename: string, bytes: Uint8Array): Promise<void> {

--- a/tests-ts/resume.test.ts
+++ b/tests-ts/resume.test.ts
@@ -36,6 +36,15 @@ describe('resume compatibility', () => {
     expect((await service.file(context)).bytes).toEqual(pdf)
   })
 
+  test('reads stored PDF bytes as a plain Uint8Array', async () => {
+    await service.upload(context, 'resume.pdf', pdf)
+    const stored = await service.file(context)
+
+    expect(stored.bytes).toEqual(pdf)
+    expect(stored.bytes).toBeInstanceOf(Uint8Array)
+    expect(Buffer.isBuffer(stored.bytes)).toBe(false)
+  })
+
   test('rejects traversal, non-PDF content, and oversized metadata before writing', async () => {
     await expect(service.upload(context, '../resume.pdf', pdf)).rejects.toThrow('Invalid resume filename')
     await expect(service.upload(context, 'resume.txt', pdf)).rejects.toThrow('Only PDF')


### PR DESCRIPTION
## 动机

调用 POST /api/resume/parse 时，FileResumeStore.read() 会把 node:fs/promises.readFile() 返回的 Buffer 作为 Uint8Array 交给 pdfjs-dist。pdfjs-dist 5.7 会显式拒绝 Buffer，导致已经上传并持久化的 PDF 简历无法解析。

## 行为变化

- 在文件存储边界把 readFile() 的结果复制为普通 Uint8Array，使运行时类型符合 ResumeStore 接口契约。
- 保持文件名、字节内容、磁盘格式和 API 响应不变。
- 增加真实文件系统回归测试，验证读回内容不变且不是 Node Buffer。

## 验证

- bun test tests-ts/resume.test.ts
- bun run check

完整检查覆盖 109 个后端/跨模块测试、Bun/Node 类型检查、架构边界、前端测试，以及 API、Web、Electron 和桌面 sidecar 构建。

## 兼容性影响

无 API、数据格式或配置变更。该修复仅让运行时字节类型匹配现有 Uint8Array 契约。