### PR TITLE
refactor(frontend): enforce generated request contracts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "node --test src/lib/registrationConfig.test.js",
+    "test": "node --test src/lib/*.test.js",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,30 @@ type JsonBody<T> = T extends { content: { "application/json": infer J } }
   ? J
   : unknown;
 
+type Operation<
+  P extends keyof paths,
+  M extends keyof paths[P],
+> = NonNullable<paths[P][M]>;
+
+type RequestBody<
+  P extends keyof paths,
+  M extends keyof paths[P],
+> = Operation<P, M> extends { requestBody?: infer R } ? NonNullable<R> : never;
+
+/**
+ * 按路径/方法从生成的 openapi schema 提取请求体类型。
+ * 默认提取 JSON；上传接口可把第三个参数指定为 multipart/form-data。
+ */
+export type ApiRequestBody<
+  P extends keyof paths,
+  M extends keyof paths[P],
+  MediaType extends string = "application/json",
+> = RequestBody<P, M> extends { content: infer Content }
+  ? MediaType extends keyof Content
+    ? Content[MediaType]
+    : never
+  : never;
+
 /**
  * 按路径/方法从生成的 openapi schema 提取 200 响应的 JSON 类型。
  * 后端目前未声明 response_model,一律解析为 unknown;

--- a/frontend/src/api/interview.ts
+++ b/frontend/src/api/interview.ts
@@ -1,4 +1,10 @@
-import { API_BASE, authFetch, consumeSSE, type ApiResponse } from "./client";
+import {
+  API_BASE,
+  authFetch,
+  consumeSSE,
+  type ApiRequestBody,
+  type ApiResponse,
+} from "./client";
 
 // 兼容旧引用:authFetch 历史上从本模块导出
 export { authFetch } from "./client";
@@ -92,19 +98,33 @@ export async function parseUploadedResume(): Promise<
 
 // ── Interview ──
 
+type StartInterviewBody = ApiRequestBody<"/api/interview/start", "post">;
+type InterviewMode = StartInterviewBody["mode"];
+type JobPrepPreviewBody = ApiRequestBody<"/api/job-prep/preview", "post">;
+type JobPrepStartBody = ApiRequestBody<"/api/job-prep/start", "post">;
+type EndInterviewBody = ApiRequestBody<
+  "/api/interview/end/{session_id}",
+  "post"
+>;
+type DraftInterviewBody = ApiRequestBody<
+  "/api/interview/draft/{session_id}",
+  "post"
+>;
+type InterviewAnswers = NonNullable<EndInterviewBody["answers"]>;
+
 interface StartInterviewOptions {
-  numQuestions?: number;
-  divergence?: number;
-  targetRole?: string;
-  jobDescription?: string;
+  numQuestions?: StartInterviewBody["num_questions"];
+  divergence?: StartInterviewBody["divergence"];
+  targetRole?: StartInterviewBody["target_role"];
+  jobDescription?: StartInterviewBody["job_description"];
 }
 
 export async function startInterview(
-  mode: string,
-  topic: string | null = null,
+  mode: InterviewMode,
+  topic: StartInterviewBody["topic"] = null,
   { numQuestions, divergence, targetRole, jobDescription }: StartInterviewOptions = {}
 ): Promise<ApiResponse<"/api/interview/start", "post">> {
-  const body: Record<string, unknown> = { mode, topic };
+  const body: StartInterviewBody = { mode, topic };
   if (numQuestions != null) body.num_questions = numQuestions;
   if (divergence != null) body.divergence = divergence;
   if (targetRole != null) body.target_role = targetRole;
@@ -129,7 +149,7 @@ export async function inferTargetRole(): Promise<
 }
 
 export async function previewJobPrep(
-  payload: Record<string, unknown>
+  payload: JobPrepPreviewBody
 ): Promise<ApiResponse<"/api/job-prep/preview", "post">> {
   const res = await authFetch(`${API_BASE}/job-prep/preview`, {
     method: "POST",
@@ -141,7 +161,7 @@ export async function previewJobPrep(
 }
 
 export async function startJobPrep(
-  payload: Record<string, unknown>
+  payload: JobPrepStartBody
 ): Promise<ApiResponse<"/api/job-prep/start", "post">> {
   const res = await authFetch(`${API_BASE}/job-prep/start`, {
     method: "POST",
@@ -198,7 +218,7 @@ export async function sendMessageStream(
 
 export async function endInterview(
   sessionId: string,
-  answers: Record<string, unknown> | null = null
+  answers: InterviewAnswers | null = null
 ): Promise<ApiResponse<"/api/interview/end/{session_id}", "post">> {
   const options: RequestInit = { method: "POST" };
   if (answers) {
@@ -212,7 +232,7 @@ export async function endInterview(
 
 export async function saveDraftAnswers(
   sessionId: string,
-  answers: Record<string, unknown>
+  answers: NonNullable<DraftInterviewBody["answers"]>
 ): Promise<ApiResponse<"/api/interview/draft/{session_id}", "post">> {
   const res = await authFetch(`${API_BASE}/interview/draft/${sessionId}`, {
     method: "POST",
@@ -264,7 +284,10 @@ export async function getTaskStatus(
 
 export async function getReferenceAnswer(
   sessionId: string,
-  questionId: string
+  questionId: ApiRequestBody<
+    "/api/interview/reference-answer",
+    "post"
+  >["question_id"]
 ): Promise<ApiResponse<"/api/interview/reference-answer", "post">> {
   const res = await authFetch(`${API_BASE}/interview/reference-answer`, {
     method: "POST",
@@ -278,7 +301,7 @@ export async function getReferenceAnswer(
 export async function getHistory(
   limit = 20,
   offset = 0,
-  mode: string | null = null,
+  mode: InterviewMode | null = null,
   topic: string | null = null
 ): Promise<ApiResponse<"/api/interview/history", "get">> {
   const params = new URLSearchParams({
@@ -334,8 +357,14 @@ export async function markProfileViewed(): Promise<
 }
 
 export async function sendPatternFeedback(
-  point: string,
-  verdict: string
+  point: ApiRequestBody<
+    "/api/profile/pattern/feedback",
+    "post"
+  >["point"],
+  verdict: ApiRequestBody<
+    "/api/profile/pattern/feedback",
+    "post"
+  >["verdict"]
 ): Promise<ApiResponse<"/api/profile/pattern/feedback", "post">> {
   const res = await authFetch(`${API_BASE}/profile/pattern/feedback`, {
     method: "POST",
@@ -459,7 +488,13 @@ export async function generateKnowledge(
 
 export async function transcribeRecording(
   audioBlob: Blob & { name?: string },
-  mode = "dual"
+  mode: NonNullable<
+    ApiRequestBody<
+      "/api/recording/transcribe",
+      "post",
+      "multipart/form-data"
+    >["mode"]
+  > = "dual"
 ): Promise<ApiResponse<"/api/recording/transcribe", "post">> {
   const form = new FormData();
   form.append("file", audioBlob, audioBlob.name || "recording.webm");
@@ -473,12 +508,14 @@ export async function transcribeRecording(
 }
 
 export async function analyzeRecording(
-  transcript: string,
-  recordingMode: string,
-  company?: string,
-  position?: string
+  transcript: ApiRequestBody<"/api/recording/analyze", "post">["transcript"],
+  recordingMode: NonNullable<
+    ApiRequestBody<"/api/recording/analyze", "post">["recording_mode"]
+  >,
+  company?: ApiRequestBody<"/api/recording/analyze", "post">["company"],
+  position?: ApiRequestBody<"/api/recording/analyze", "post">["position"]
 ): Promise<ApiResponse<"/api/recording/analyze", "post">> {
-  const body: Record<string, unknown> = {
+  const body: ApiRequestBody<"/api/recording/analyze", "post"> = {
     transcript,
     recording_mode: recordingMode,
   };
@@ -529,7 +566,7 @@ export async function getSettings(): Promise<
 }
 
 export async function updateSettings(
-  payload: Record<string, unknown>
+  payload: ApiRequestBody<"/api/settings", "put">
 ): Promise<ApiResponse<"/api/settings", "put">> {
   const res = await authFetch(`${API_BASE}/settings`, {
     method: "PUT",
@@ -540,31 +577,25 @@ export async function updateSettings(
   return res.json();
 }
 
-interface LLMConnectionPayload {
-  api_base?: string;
-  api_key?: string;
-  model?: string;
-}
+type LLMConnectionPayload = ApiRequestBody<"/api/settings/test-llm", "post">;
 
 // 连接测试：探测「表单里当前填的」配置（尚未保存也能测），返回 { ok, error }
-export async function testLLMConnection({
-  api_base,
-  api_key,
-  model,
-}: LLMConnectionPayload): Promise<
+export async function testLLMConnection(
+  payload: LLMConnectionPayload
+): Promise<
   ApiResponse<"/api/settings/test-llm", "post">
 > {
   const res = await authFetch(`${API_BASE}/settings/test-llm`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ api_base, api_key, model }),
+    body: JSON.stringify(payload),
   });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
 
 export async function testEmbeddingConnection(
-  payload: Record<string, unknown>
+  payload: ApiRequestBody<"/api/settings/test-embedding", "post">
 ): Promise<ApiResponse<"/api/settings/test-embedding", "post">> {
   const res = await authFetch(`${API_BASE}/settings/test-embedding`, {
     method: "POST",

--- a/frontend/src/lib/interviewAnswers.js
+++ b/frontend/src/lib/interviewAnswers.js
@@ -1,0 +1,17 @@
+function serializeConfidence(confidence) {
+  if (confidence === "high") return 1;
+  if (confidence === "low") return 0;
+  return undefined;
+}
+
+/** Build the API answer payload while keeping UI confidence labels out of it. */
+export function buildInterviewAnswers(questions, answers, confidences = {}) {
+  return questions.map((question) => {
+    const confidence = serializeConfidence(confidences[question.id]);
+    return {
+      question_id: question.id,
+      answer: answers[question.id] || "",
+      ...(confidence === undefined ? {} : { confidence }),
+    };
+  });
+}

--- a/frontend/src/lib/interviewAnswers.test.js
+++ b/frontend/src/lib/interviewAnswers.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildInterviewAnswers } from "./interviewAnswers.js";
+
+test("serializes high and low confidence as numbers", () => {
+  const payload = buildInterviewAnswers(
+    [{ id: 1 }, { id: "question-2" }],
+    { 1: "first answer", "question-2": "second answer" },
+    { 1: "high", "question-2": "low" },
+  );
+
+  assert.deepEqual(payload, [
+    { question_id: 1, answer: "first answer", confidence: 1 },
+    { question_id: "question-2", answer: "second answer", confidence: 0 },
+  ]);
+});
+
+test("omits confidence when the user has not selected one", () => {
+  const payload = buildInterviewAnswers(
+    [{ id: 1 }, { id: 2 }],
+    { 1: "answered" },
+    { 2: "unexpected-value" },
+  );
+
+  assert.deepEqual(payload, [
+    { question_id: 1, answer: "answered" },
+    { question_id: 2, answer: "" },
+  ]);
+});

--- a/frontend/src/pages/Interview.jsx
+++ b/frontend/src/pages/Interview.jsx
@@ -6,6 +6,7 @@ import ChatBubble from "../components/ChatBubble";
 import { sendMessage, sendMessageStream, endInterview, retryReview, getResumableSession, saveDraftAnswers } from "../api/interview";
 import useTaskStatus from "../hooks/useTaskStatus";
 import useVoiceInput from "../hooks/useVoiceInput";
+import { buildInterviewAnswers } from "../lib/interviewAnswers";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -194,11 +195,7 @@ export default function Interview() {
     if (submitted && !isRetry) return;
     setSubmitting(true);
     try {
-      const answerList = questions.map((q) => ({
-        question_id: q.id,
-        answer: answers[q.id] || "",
-        ...(confidences[q.id] ? { confidence: confidences[q.id] === "high" ? 1 : 0 } : {}),
-      }));
+      const answerList = buildInterviewAnswers(questions, answers, confidences);
       await endInterview(sessionId, answerList);
       setSubmitted(true);
       setFinished(true);

--- a/frontend/src/pages/JobPrep.tsx
+++ b/frontend/src/pages/JobPrep.tsx
@@ -208,10 +208,14 @@ export default function JobPrep({ embedded = false }: JobPrepProps) {
   };
 
   const handleStart = async () => {
+    if (!preview) return;
     setStarting(true);
     setError("");
     try {
-      const data = await startJobPrep({ ...payload, preview_data: preview }) as unknown as { session_id: string; [key: string]: unknown };
+      const data = await startJobPrep({
+        ...payload,
+        preview_data: { ...preview },
+      }) as unknown as { session_id: string; [key: string]: unknown };
       try { localStorage.removeItem(DRAFT_KEY); } catch { /* ignore */ }
       navigate(`/interview/${data.session_id}`, { state: data });
     } catch (err) {


### PR DESCRIPTION
Summary:
- derive frontend request payloads and enum values from generated OpenAPI types
- centralize interview confidence serialization with numeric high/low mapping
- guard JD preview reuse against null and add serialization regression tests

Validation:
- bun run --cwd frontend typecheck
- bun run test:web (5 passed)
- bun test tests-ts/http-nullable-contracts.test.ts tests-ts/settings-provider.test.ts tests-ts/recording.test.ts (20 passed)
- bun run --cwd frontend lint (passes with existing warnings)
- bun run --cwd frontend build
- bun run --cwd frontend gen:api (no generated diff)