### PR TITLE
fix(interview): harden structured LLM responses

### DIFF
--- a/packages/core/src/interview/interview-service.ts
+++ b/packages/core/src/interview/interview-service.ts
@@ -1,5 +1,5 @@
 import type { RequestContext } from '../kernel/context.ts'
-import { AppError, AuthenticationError } from '../kernel/errors.ts'
+import { AppError, AuthenticationError, ProviderResponseError } from '../kernel/errors.ts'
 import { parseJsonResponse } from '../kernel/json.ts'
 import type { InterviewUseCases, InterviewDependencies } from './ports.ts'
 import type {
@@ -38,6 +38,10 @@ function questions(value: unknown, limit: number): InterviewQuestion[] {
     const difficulty = Number(source.difficulty || 3)
     return [{ ...source, id: source.id as string | number ?? index + 1, question, difficulty: Number.isFinite(difficulty) ? difficulty : 3 } as InterviewQuestion]
   })
+}
+
+function topicQuestionMaxTokens(count: number): number {
+  return Math.min(8192, Math.max(2048, count * 512))
 }
 
 function answerMap(answers: InterviewAnswer[]): Map<string, string> {
@@ -186,11 +190,16 @@ export class InterviewService implements InterviewUseCases {
         this.deps.sessions.recentQuestions(id, input.topic),
         this.deps.profile.summary(id, input.topic),
       ])
-      const generated = questions(parseJsonResponse(await this.deps.ai.complete(context, [
+      const messages = [
         { role: 'system', content: '你是专项训练出题引擎。只返回 JSON 数组。' },
         { role: 'user', content: fill(DRILL_QUESTION_PROMPT, { topic_name: topics[input.topic]!.name, num_questions: count, knowledge_context: knowledge, user_profile: profile, high_frequency: highFrequency.slice(0, 4000) || '暂无', recent_questions: recent.map((value) => `- ${value}`).join('\n') || '暂无', divergence }) },
-      ])), count)
-      if (!generated.length) throw new AppError('出题失败，LLM 返回格式异常', 500)
+      ] as const
+      let generated: InterviewQuestion[] = []
+      for (let attempt = 0; attempt < 2 && generated.length !== count; attempt += 1) {
+        const text = await this.deps.ai.complete(context, messages, { maxTokens: topicQuestionMaxTokens(count) })
+        try { generated = questions(parseJsonResponse(text), count) } catch { generated = [] }
+      }
+      if (generated.length !== count) throw new ProviderResponseError('模型返回的专项训练题目不完整，已自动重试，请稍后再试或更换模型。')
       await this.deps.sessions.create({ sessionId, userId: id, mode: 'topic_drill', topic: input.topic, questions: generated })
       return { session_id: sessionId, mode: 'topic_drill', topic: input.topic, questions: generated }
     }

--- a/packages/core/src/kernel/errors.ts
+++ b/packages/core/src/kernel/errors.ts
@@ -28,6 +28,12 @@ export class ProviderNotConfigured extends AppError {
   }
 }
 
+export class ProviderResponseError extends AppError {
+  constructor(message = '模型服务没有返回有效内容，请稍后重试或更换模型。') {
+    super(message, 502, 'provider_response_error')
+  }
+}
+
 export class QuotaExceeded extends AppError {
   constructor(message: string) {
     super(message, 402, 'quota_exceeded')

--- a/packages/core/src/provider/settings-operations.ts
+++ b/packages/core/src/provider/settings-operations.ts
@@ -1,4 +1,5 @@
 import { AuthenticationError } from '../kernel/errors.ts'
+import { parseJsonResponse } from '../kernel/json.ts'
 import type { RequestContext } from '../kernel/context.ts'
 import type { KnowledgeVectorRepository, KnowledgeStore } from '../knowledge/ports.ts'
 import type { PersonalAgentUseCases } from '../personal-agent/ports.ts'
@@ -21,6 +22,26 @@ function message(error: unknown): string {
 }
 function userId(context: RequestContext): string { if (!context.userId) throw new AuthenticationError(); return context.userId }
 
+const LLM_PROBE_MESSAGES = [
+  { role: 'system' as const, content: '你是专项训练出题引擎。只返回 JSON 数组，不要其他内容。' },
+  { role: 'user' as const, content: '请生成 2 道 JavaScript 专项训练题，只返回严格 JSON 数组。每项包含 id、question、difficulty、focus_area，必须完整闭合。' },
+]
+
+function validateLlmProbe(text: string): void {
+  try {
+    const value = parseJsonResponse(text)
+    if (!Array.isArray(value) || value.length !== 2 || !value.every((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return false
+      const question = item as Record<string, unknown>
+      return typeof question.question === 'string' && question.question.trim().length > 0
+        && typeof question.focus_area === 'string' && question.focus_area.trim().length > 0
+        && Number.isFinite(Number(question.difficulty))
+    })) throw new SyntaxError('Unexpected structured probe response')
+  } catch (error) {
+    throw new Error('模型已连接，但未返回完整的专项训练结构化结果；请换用支持长文本 JSON 输出的模型。', { cause: error })
+  }
+}
+
 export class SettingsOperationsService implements SettingsOperationsUseCases {
   constructor(private readonly deps: {
     chats: ChatDriverFactory
@@ -37,7 +58,8 @@ export class SettingsOperationsService implements SettingsOperationsUseCases {
   async testLlm(context: RequestContext, value: LlmSettings): Promise<{ ok: boolean; error?: string }> {
     try {
       if (!value.api_key.trim() || !value.model.trim()) throw new Error('请先填写必填字段')
-      await this.deps.chats.create({ ...value, source: USER_PROVIDER }).complete([{ role: 'user', content: 'ping' }], context.signal, { maxTokens: 1, temperature: 0 })
+      const result = await this.deps.chats.create({ ...value, source: USER_PROVIDER }).complete(LLM_PROBE_MESSAGES, context.signal, { maxTokens: 2048, temperature: 0 })
+      validateLlmProbe(result.text)
       return { ok: true }
     } catch (error) { return { ok: false, error: message(error) } }
   }

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai'
 import { createHash, createHmac, randomUUID } from 'node:crypto'
 import {
   DEFAULT_EMBEDDING_MODEL,
+  ProviderResponseError,
   embeddingModeOf,
   normalizeEmbeddingApiBase,
   type ChatDriver,
@@ -24,25 +25,61 @@ import {
 
 export { normalizeEmbeddingApiBase } from '@techspar/core'
 
+const DEFAULT_EMPTY_COMPLETION_RETRY_DELAYS_MS = [250, 750] as const
+
+type ChatFactoryOptions = {
+  fetch?: typeof globalThis.fetch
+  retryDelaysMs?: readonly number[]
+  sleep?: (milliseconds: number, signal: AbortSignal) => Promise<void>
+}
+
+async function abortableSleep(milliseconds: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) throw signal.reason || new Error('Request aborted')
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, milliseconds)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal.reason || new Error('Request aborted'))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
 export class OpenAiChatDriverFactory implements ChatDriverFactory {
+  constructor(private readonly options: ChatFactoryOptions = {}) {}
+
   create(config: ResolvedLlmConfig): ChatDriver {
-    const client = new OpenAI({ apiKey: config.api_key, baseURL: config.api_base || undefined })
+    const client = new OpenAI({
+      apiKey: config.api_key,
+      baseURL: config.api_base || undefined,
+      ...(this.options.fetch ? { fetch: this.options.fetch } : {}),
+    })
+    const retryDelaysMs = this.options.retryDelaysMs || DEFAULT_EMPTY_COMPLETION_RETRY_DELAYS_MS
+    const sleep = this.options.sleep || abortableSleep
     return {
       async complete(messages: readonly ChatMessage[], signal: AbortSignal, options?: { maxTokens?: number; temperature?: number }) {
-        const response = await client.chat.completions.create(
-          {
-            model: config.model,
-            messages: [...messages],
-            temperature: options?.temperature ?? config.temperature,
-            ...(options?.maxTokens === undefined ? {} : { max_tokens: options.maxTokens }),
-          },
-          { signal },
-        )
-        return {
-          text: response.choices[0]?.message.content || '',
-          promptTokens: response.usage?.prompt_tokens || 0,
-          completionTokens: response.usage?.completion_tokens || 0,
+        let promptTokens = 0
+        let completionTokens = 0
+        for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
+          const response = await client.chat.completions.create(
+            {
+              model: config.model,
+              messages: [...messages],
+              temperature: options?.temperature ?? config.temperature,
+              ...(options?.maxTokens === undefined ? {} : { max_tokens: options.maxTokens }),
+            },
+            { signal },
+          )
+          promptTokens += response.usage?.prompt_tokens || 0
+          completionTokens += response.usage?.completion_tokens || 0
+          const text = response.choices?.[0]?.message.content || ''
+          if (text.trim()) return { text, promptTokens, completionTokens }
+          if (attempt < retryDelaysMs.length) await sleep(retryDelaysMs[attempt]!, signal)
         }
+        throw new ProviderResponseError('模型服务连续返回空内容，已自动重试，请稍后再试或更换模型。')
       },
       async *stream(messages: readonly ChatMessage[], signal: AbortSignal, options?: { temperature?: number }) {
         const response = await client.chat.completions.create(

--- a/tests-ts/http-nullable-contracts.test.ts
+++ b/tests-ts/http-nullable-contracts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import type { CopilotPrepUseCases, InterviewUseCases, JobPrepInput, PersonalAgentUseCases, StartInterviewInput } from '@techspar/core'
+import { ProviderResponseError, type CopilotPrepUseCases, type InterviewUseCases, type JobPrepInput, type PersonalAgentUseCases, type StartInterviewInput } from '@techspar/core'
 import { createApp, type AppDependencies } from '../apps/api/src/app.ts'
 
 const unavailable = new Proxy({}, { get() { return () => Promise.reject(new Error('unexpected dependency call')) } })
@@ -93,6 +93,16 @@ describe('legacy nullable HTTP request contracts', () => {
 })
 
 describe('FastAPI-compatible HTTP validation', () => {
+  test('keeps provider response failures as a readable 502', async () => {
+    const interview = { async start() { throw new ProviderResponseError('模型服务连续返回空内容，请稍后再试。') } } as unknown as InterviewUseCases
+    const response = await boundaryApp({ interview }).request('/api/interview/start', {
+      method: 'POST', headers, body: JSON.stringify({ mode: 'topic_drill', topic: 'typescript' }),
+    })
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({ detail: '模型服务连续返回空内容，请稍后再试。', code: 'provider_response_error' })
+  })
+
   test('keeps malformed JSON as a JSON 400 response', async () => {
     const response = await boundaryApp({}).request('/api/auth/login', {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: '{',

--- a/tests-ts/interview.test.ts
+++ b/tests-ts/interview.test.ts
@@ -31,9 +31,11 @@ const context: RequestContext = { requestId: 'test', userId: 'user-a', signal: n
 
 class FakeAi implements TextGenerationUseCases {
   calls: ChatMessage[][] = []
+  options: Array<{ maxTokens?: number; temperature?: number } | undefined> = []
   constructor(private readonly replies: string[]) {}
-  async complete(_context: RequestContext, messages: readonly ChatMessage[]): Promise<string> {
+  async complete(_context: RequestContext, messages: readonly ChatMessage[], options?: { maxTokens?: number; temperature?: number }): Promise<string> {
     this.calls.push([...messages])
+    this.options.push(options)
     const reply = this.replies.shift()
     if (reply === undefined) throw new Error('Unexpected LLM call')
     return reply
@@ -213,6 +215,43 @@ describe('interview application service', () => {
     await service.start(context, { mode: 'topic_drill', topic: 'typescript', num_questions: 1 })
     expect(ai.calls[0]![1]!.content).toContain('本轮到期复习：微任务队列')
     expect(ai.calls[0]![1]!.content).toContain('历史语义洞察：上次忽略了饿饿问题')
+    sessions.close(); states.close()
+  })
+
+  test('retries an incomplete topic drill batch and sets a bounded output limit', async () => {
+    const path = await databasePath()
+    const sessions = new BunInterviewSessionRepository(path); sessions.initialize()
+    const states = new BunResumeInterviewStateRepository(path); states.initialize()
+    const completeQuestions = Array.from({ length: 10 }, (_, index) => ({ id: index + 1, question: `事件循环问题 ${index + 1}`, difficulty: 3 }))
+    const ai = new FakeAi([JSON.stringify(completeQuestions.slice(0, 1)), JSON.stringify(completeQuestions)])
+    const service = new InterviewService(interviewDependencies({
+      sessions, states, ai,
+      knowledgeStore: emptyKnowledgeStore({ typescript: { name: 'TypeScript', icon: '', dir: 'typescript' } }),
+    }))
+
+    const result = await service.start(context, { mode: 'topic_drill', topic: 'typescript', num_questions: 10 })
+    expect(result.questions).toHaveLength(10)
+    expect(ai.calls).toHaveLength(2)
+    expect(ai.options).toEqual([{ maxTokens: 5120 }, { maxTokens: 5120 }])
+    sessions.close(); states.close()
+  })
+
+  test('returns a readable 502 after repeated truncated topic drill JSON', async () => {
+    const path = await databasePath()
+    const sessions = new BunInterviewSessionRepository(path); sessions.initialize()
+    const states = new BunResumeInterviewStateRepository(path); states.initialize()
+    const ai = new FakeAi(['[{"id":1', '[{"id":1'])
+    const service = new InterviewService(interviewDependencies({
+      sessions, states, ai,
+      knowledgeStore: emptyKnowledgeStore({ typescript: { name: 'TypeScript', icon: '', dir: 'typescript' } }),
+    }))
+
+    await expect(service.start(context, { mode: 'topic_drill', topic: 'typescript', num_questions: 10 })).rejects.toMatchObject({
+      status: 502,
+      code: 'provider_response_error',
+      message: '模型返回的专项训练题目不完整，已自动重试，请稍后再试或更换模型。',
+    })
+    expect(ai.calls).toHaveLength(2)
     sessions.close(); states.close()
   })
 

--- a/tests-ts/providers.test.ts
+++ b/tests-ts/providers.test.ts
@@ -1,6 +1,57 @@
 import { describe, expect, test } from 'bun:test'
-import { DEFAULT_EMBEDDING_MODEL } from '@techspar/core'
-import { ApiEmbeddingClient, PcmSpeechSegmenter, normalizeEmbeddingApiBase } from '@techspar/providers'
+import { DEFAULT_EMBEDDING_MODEL, USER_PROVIDER } from '@techspar/core'
+import { ApiEmbeddingClient, OpenAiChatDriverFactory, PcmSpeechSegmenter, normalizeEmbeddingApiBase } from '@techspar/providers'
+
+function completion(choices: unknown, usage = { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 }) {
+  return { id: 'chatcmpl-test', object: 'chat.completion', created: 0, model: 'test-model', choices, usage }
+}
+
+function chatFetch(replies: unknown[], requests: Array<Record<string, unknown>>): typeof globalThis.fetch {
+  return (async (_input: string | URL | Request, init?: RequestInit) => {
+    requests.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+    const reply = replies.length > 1 ? replies.shift() : replies[0]
+    return new Response(JSON.stringify(reply), { status: 200, headers: { 'content-type': 'application/json' } })
+  }) as typeof globalThis.fetch
+}
+
+describe('chat provider compatibility', () => {
+  const config = { api_base: 'https://example.test/v1', api_key: 'key', model: 'test-model', temperature: 0.7, source: USER_PROVIDER }
+  const valid = completion([{ index: 0, message: { role: 'assistant', content: '[{"id":1,"question":"题目"}]' }, finish_reason: 'stop' }], { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 })
+
+  test('retries null choices with backoff and preserves the output limit', async () => {
+    const requests: Array<Record<string, unknown>> = []
+    const delays: number[] = []
+    const factory = new OpenAiChatDriverFactory({
+      fetch: chatFetch([completion(null), valid], requests),
+      retryDelaysMs: [10, 20],
+      sleep: async (milliseconds) => { delays.push(milliseconds) },
+    })
+    const result = await factory.create(config).complete([{ role: 'user', content: 'generate' }], new AbortController().signal, { maxTokens: 4096 })
+
+    expect(result).toEqual({ text: '[{"id":1,"question":"题目"}]', promptTokens: 4, completionTokens: 4 })
+    expect(delays).toEqual([10])
+    expect(requests).toHaveLength(2)
+    expect(requests.every((request) => request.max_tokens === 4096)).toBeTrue()
+  })
+
+  test('raises a readable 502 after repeated null choices', async () => {
+    const requests: Array<Record<string, unknown>> = []
+    const delays: number[] = []
+    const factory = new OpenAiChatDriverFactory({
+      fetch: chatFetch([completion(null)], requests),
+      retryDelaysMs: [10, 20],
+      sleep: async (milliseconds) => { delays.push(milliseconds) },
+    })
+
+    await expect(factory.create(config).complete([{ role: 'user', content: 'generate' }], new AbortController().signal)).rejects.toMatchObject({
+      status: 502,
+      code: 'provider_response_error',
+      message: '模型服务连续返回空内容，已自动重试，请稍后再试或更换模型。',
+    })
+    expect(requests).toHaveLength(3)
+    expect(delays).toEqual([10, 20])
+  })
+})
 
 describe('embedding provider compatibility', () => {
   test('defaults local inference to a Transformers.js ONNX checkpoint', () => {

--- a/tests-ts/settings-provider.test.ts
+++ b/tests-ts/settings-provider.test.ts
@@ -121,17 +121,34 @@ describe('settings persistence', () => {
 describe('settings operations', () => {
   test('tests submitted provider values without reading persisted settings', async () => {
     let llmConfig: Record<string, unknown> | undefined
+    let llmMessages: Array<Record<string, unknown>> | undefined
+    let llmOptions: Record<string, unknown> | undefined
     let embeddingConfig: Record<string, unknown> | undefined
     const service = new SettingsOperationsService({
-      chats: { create(config: Record<string, unknown>) { llmConfig = config; return { async complete() { return { text: 'pong', promptTokens: 1, completionTokens: 1 } }, async *stream() {} } } },
+      chats: { create(config: Record<string, unknown>) { llmConfig = config; return { async complete(messages: Array<Record<string, unknown>>, _signal: unknown, options: Record<string, unknown>) { llmMessages = messages; llmOptions = options; return { text: JSON.stringify([{ id: 1, question: '闭包是什么？', difficulty: 2, focus_area: '闭包' }, { id: 2, question: '事件循环如何工作？', difficulty: 3, focus_area: '事件循环' }]), promptTokens: 1, completionTokens: 1 } }, async *stream() {} } } },
       embeddingDrivers: { async create(config: Record<string, unknown>) { embeddingConfig = config; return { async embed() { return [Float32Array.from([1])] } } } },
       embeddings: {}, index: {}, vectors: {}, knowledge: {}, personal: {}, profile: {}, settings: {},
     } as never)
     const context = { requestId: 'test', userId: 'user', signal: new AbortController().signal }
     expect(await service.testLlm(context, { api_base: 'https://submitted.test/v1', api_key: 'submitted-key', model: 'submitted-model', temperature: 0.2 })).toEqual({ ok: true })
     expect(llmConfig).toMatchObject({ api_base: 'https://submitted.test/v1', api_key: 'submitted-key', model: 'submitted-model', source: USER_PROVIDER })
+    expect(llmMessages?.map((message) => message.content).join('\n')).toContain('专项训练')
+    expect(llmOptions).toEqual({ maxTokens: 2048, temperature: 0 })
     expect(await service.testEmbedding(context, { backend: 'local', api_base: '', api_key: '', api_model: '', local_model: 'Xenova/bge-m3', local_path: '', api_batch_size: 10 })).toEqual({ ok: true })
     expect(embeddingConfig).toMatchObject({ backend: 'local', local_model: 'Xenova/bge-m3', source: USER_PROVIDER })
+  })
+
+  test('rejects a truncated structured LLM probe even when the request itself succeeds', async () => {
+    const service = new SettingsOperationsService({
+      chats: { create() { return { async complete() { return { text: '[{"id":1,"question":"未闭合"', promptTokens: 1, completionTokens: 1 } }, async *stream() {} } } },
+      embeddingDrivers: {}, embeddings: {}, index: {}, vectors: {}, knowledge: {}, personal: {}, profile: {}, settings: {},
+    } as never)
+    const context = { requestId: 'test', userId: 'user', signal: new AbortController().signal }
+
+    expect(await service.testLlm(context, { api_base: 'https://submitted.test/v1', api_key: 'submitted-key', model: 'submitted-model', temperature: 0.2 })).toEqual({
+      ok: false,
+      error: '模型已连接，但未返回完整的专项训练结构化结果；请换用支持长文本 JSON 输出的模型。',
+    })
   })
 
   test('streams rebuild progress and persists the completion time', async () => {


### PR DESCRIPTION
## Summary
- retry intermittent empty ModelScope completions with bounded backoff and return a readable 502
- replace the one-token connection probe with a structured topic-drill probe
- bound topic-drill output tokens and retry malformed or incomplete JSON
- add regression coverage for null choices, truncation, incomplete batches, and HTTP error mapping

## Validation
- bun run test (116 passed)
- bun run typecheck
- bun run typecheck:node
- bun run check:boundaries
- bun run build:api

Fixes #55