### PR TITLE
feat(provider): add DeepSeek structured output compatibility

### DIFF
--- a/apps/desktop/src/backend-supervisor.ts
+++ b/apps/desktop/src/backend-supervisor.ts
@@ -57,7 +57,7 @@ export class BackendSupervisor {
         finish(undefined, { origin: `http://${host}:${message.port}`, port: Number(message.port) })
       })
       child.once('error', (error) => finish(error))
-      child.once('exit', (code, signal) => {
+      child.once('close', (code, signal) => {
         const detail = `TechSpar backend exited (${signal || (code ?? 'unknown')})${stderr ? `\n${stderr}` : ''}`
         if (!this.ready) finish(new Error(detail))
         else if (!this.stopping) this.onUnexpectedExit?.(detail)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,7 +4,7 @@
 
 ## LLM
 
-填写 OpenAI-compatible API Base、API Key、Model 和 Temperature。先点击测试，确认账号确实能调用该模型，再保存。训练、面试、复盘、个人 Agent 和 Copilot 都使用这套生效中的配置。
+填写 OpenAI-compatible API Base、API Key、Model、API 兼容模式和 Temperature。普通平台选择“通用 OpenAI 兼容”；DeepSeek V4 选择“DeepSeek V4”。先点击测试，确认账号确实能调用该模型，再保存。训练、面试、复盘、个人 Agent 和 Copilot 都使用这套生效中的配置。DeepSeek 模式只会对结构化请求附加 JSON 输出和低推理参数，普通文本请求及其他平台不会收到这些字段。
 
 ## Embedding
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -286,6 +286,11 @@ export interface paths {
                                 model: string;
                                 /** @default 0.7 */
                                 temperature: number;
+                                /**
+                                 * @default generic
+                                 * @enum {string}
+                                 */
+                                compatibility: "generic" | "deepseek";
                             };
                             /**
                              * @default {
@@ -394,6 +399,11 @@ export interface paths {
                             model?: string;
                             /** @default 0.7 */
                             temperature?: number;
+                            /**
+                             * @default generic
+                             * @enum {string}
+                             */
+                            compatibility?: "generic" | "deepseek";
                         };
                         /**
                          * @default {
@@ -580,6 +590,11 @@ export interface paths {
                         model?: string;
                         /** @default 0.7 */
                         temperature?: number;
+                        /**
+                         * @default generic
+                         * @enum {string}
+                         */
+                        compatibility?: "generic" | "deepseek";
                     };
                 };
             };

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -31,6 +31,7 @@ export default function Onboarding() {
   const [apiBase, setApiBase] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState("");
+  const [compatibility, setCompatibility] = useState("generic");
   const [embApiBase, setEmbApiBase] = useState("");
   const [embApiKey, setEmbApiKey] = useState("");
   const [embApiModel, setEmbApiModel] = useState("");
@@ -44,6 +45,7 @@ export default function Onboarding() {
         setApiBase(data.llm?.api_base || "");
         setApiKey(data.llm?.api_key || "");
         setModel(data.llm?.model || "");
+        setCompatibility(data.llm?.compatibility || "generic");
         const emb = data.embedding || {};
         setEmbApiBase(emb.api_base || "");
         setEmbApiKey(emb.api_key || "");
@@ -66,6 +68,7 @@ export default function Onboarding() {
         api_base: apiBase.trim(),
         api_key: apiKey.trim(),
         model: model.trim(),
+        compatibility,
       });
       if (!r.ok) {
         setError("LLM 连接失败：" + r.error);
@@ -99,6 +102,7 @@ export default function Onboarding() {
           api_base: apiBase.trim(),
           api_key: apiKey.trim(),
           model: model.trim(),
+          compatibility,
           temperature: base?.llm?.temperature ?? 0.7,
         },
         embedding: {
@@ -185,6 +189,23 @@ export default function Onboarding() {
                 <div className="space-y-2">
                   <Label className={labelClass}>Model</Label>
                   <Input className={inputClass} autoComplete="off" placeholder="例：ZhipuAI/GLM-5" value={model} onChange={(e) => setModel(e.target.value)} />
+                </div>
+                <div className="space-y-2">
+                  <Label className={labelClass}>API 兼容模式</Label>
+                  <label className="flex items-center justify-between gap-3 rounded-2xl border border-border/80 bg-background/75 px-3 py-2.5 text-sm">
+                    <span className="shrink-0 text-dim">请求配置</span>
+                    <select
+                      className="min-w-0 flex-1 bg-transparent text-right text-text outline-none"
+                      value={compatibility}
+                      onChange={(e) => setCompatibility(e.target.value)}
+                    >
+                      <option value="generic">通用 OpenAI 兼容</option>
+                      <option value="deepseek">DeepSeek V4</option>
+                    </select>
+                  </label>
+                  <div className="text-[12px] text-dim/70">
+                    {compatibility === "deepseek" ? "DeepSeek 官方 API 填 https://api.deepseek.com（不要加 /v1）" : "多数 OpenAI 兼容服务填写包含 /v1 的 Base URL。"}
+                  </div>
                 </div>
                 <div className="space-y-2">
                   <Label className={labelClass}>API Key</Label>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -117,6 +117,7 @@ export default function Settings() {
   const [apiBase, setApiBase] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState("");
+  const [compatibility, setCompatibility] = useState("generic");
   const [temperature, setTemperature] = useState(0.7);
   const [numQuestions, setNumQuestions] = useState(10);
   const [divergence, setDivergence] = useState(3);
@@ -227,6 +228,7 @@ export default function Settings() {
         setApiBase(data.llm.api_base || "");
         setApiKey(data.llm.api_key || "");
         setModel(data.llm.model || "");
+        setCompatibility(data.llm.compatibility || "generic");
         setTemperature(data.llm.temperature ?? 0.7);
         const emb = data.embedding || {};
         setEmbBackend(emb.backend || "");
@@ -514,7 +516,7 @@ export default function Settings() {
   const handleTestLLM = async () => {
     setLlmTest({ status: "testing" });
     try {
-      const r = await testLLMConnection({ api_base: apiBase, api_key: apiKey, model });
+      const r = await testLLMConnection({ api_base: apiBase, api_key: apiKey, model, compatibility });
       setLlmTest(r.ok ? { status: "ok" } : { status: "fail", error: r.error });
     } catch (err) {
       setLlmTest({ status: "fail", error: err.message });
@@ -544,7 +546,7 @@ export default function Settings() {
     setError("");
     try {
       const res = await updateSettings({
-        llm: { api_base: apiBase, api_key: apiKey, model, temperature },
+        llm: { api_base: apiBase, api_key: apiKey, model, compatibility, temperature },
         embedding: {
           backend: embBackend,
           api_base: embApiBase,
@@ -718,6 +720,9 @@ export default function Settings() {
                   value={apiBase}
                   onChange={(e) => setApiBase(e.target.value)}
                 />
+                <div className="text-[12px] text-dim/70">
+                  {compatibility === "deepseek" ? "DeepSeek 官方 API 填 https://api.deepseek.com（不要加 /v1）" : "多数 OpenAI 兼容服务填写包含 /v1 的 Base URL。"}
+                </div>
               </div>
               <div className="space-y-2">
                 <Label className={labelClass}>Model</Label>
@@ -727,6 +732,23 @@ export default function Settings() {
                   value={model}
                   onChange={(e) => setModel(e.target.value)}
                 />
+              </div>
+              <div className="space-y-2">
+                <Label className={labelClass}>API 兼容模式</Label>
+                <label className="flex items-center justify-between gap-3 rounded-2xl border border-border/80 bg-background/75 px-3 py-2.5 text-sm">
+                  <span className="shrink-0 text-dim">请求配置</span>
+                  <select
+                    className="min-w-0 flex-1 bg-transparent text-right text-text outline-none"
+                    value={compatibility}
+                    onChange={(e) => setCompatibility(e.target.value)}
+                  >
+                    <option value="generic">通用 OpenAI 兼容</option>
+                    <option value="deepseek">DeepSeek V4</option>
+                  </select>
+                </label>
+                <div className="text-[12px] text-dim/70">
+                  DeepSeek 模式只对结构化请求发送 JSON 输出和低推理参数，其他平台不会收到这些字段。
+                </div>
               </div>
             </div>
 

--- a/packages/contracts/openapi.json
+++ b/packages/contracts/openapi.json
@@ -384,6 +384,14 @@
                           "minimum": 0,
                           "maximum": 2,
                           "default": 0.7
+                        },
+                        "compatibility": {
+                          "type": "string",
+                          "enum": [
+                            "generic",
+                            "deepseek"
+                          ],
+                          "default": "generic"
                         }
                       }
                     },
@@ -572,6 +580,14 @@
                         "minimum": 0,
                         "maximum": 2,
                         "default": 0.7
+                      },
+                      "compatibility": {
+                        "type": "string",
+                        "enum": [
+                          "generic",
+                          "deepseek"
+                        ],
+                        "default": "generic"
                       }
                     }
                   },
@@ -841,6 +857,14 @@
                     "minimum": 0,
                     "maximum": 2,
                     "default": 0.7
+                  },
+                  "compatibility": {
+                    "type": "string",
+                    "enum": [
+                      "generic",
+                      "deepseek"
+                    ],
+                    "default": "generic"
                   }
                 }
               }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -50,6 +50,7 @@ export const LlmSettingsSchema = z.object({
   api_key: z.string().default(''),
   model: z.string().default(''),
   temperature: z.number().min(0).max(2).default(0.7),
+  compatibility: z.enum(['generic', 'deepseek']).default('generic'),
 })
 
 export const EmbeddingSettingsSchema = z.object({

--- a/packages/core/src/copilot/prep-service.ts
+++ b/packages/core/src/copilot/prep-service.ts
@@ -1,6 +1,7 @@
 import type { RequestContext } from '../kernel/context.ts'
 import { AppError, AuthenticationError } from '../kernel/errors.ts'
 import { parseJsonResponse } from '../kernel/json.ts'
+import { STRUCTURED_CHAT_OPTIONS } from '../provider/ports.ts'
 import { fill } from '../interview/prompts.ts'
 import type { TaskRecord } from '../interview/model.ts'
 import type { CopilotDependencies, CopilotPrepUseCases, SearchResult } from './ports.ts'
@@ -71,22 +72,22 @@ export class CopilotPrepService implements CopilotPrepUseCases {
       const company = (async () => {
         const results = await this.search(context, services.tavily_api_key, prep.company, prep.position)
         if (!results.length) return JSON.stringify({ company_name: prep.company || '未知', tech_stack: [], interview_style: '无法获取（未配置搜索 API 或搜索无结果）', culture_notes: '', common_focus_areas: [], sources: [] })
-        return (await this.deps.ai.complete(context, [{ role: 'system', content: '你是面试情报分析师。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_COMPANY_PROMPT, { company: prep.company, position: prep.position, results: json(results) }) }])).trim()
+        return (await this.deps.ai.complete(context, [{ role: 'system', content: '你是面试情报分析师。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_COMPANY_PROMPT, { company: prep.company, position: prep.position, results: json(results) }) }], STRUCTURED_CHAT_OPTIONS)).trim()
       })()
-      const jd = this.deps.ai.complete(context, [{ role: 'system', content: '你是 JD 分析引擎。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_JD_PROMPT, { jd_text: prep.jd_text.slice(0, 6000) }) }])
-      const fit = this.deps.ai.complete(context, [{ role: 'system', content: '你是匹配分析引擎。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_FIT_PROMPT, { jd_text: prep.jd_text.slice(0, 6000), resume_context: resumeText.slice(0, 5000) || '未上传简历', profile_summary: profileSummary }) }])
+      const jd = this.deps.ai.complete(context, [{ role: 'system', content: '你是 JD 分析引擎。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_JD_PROMPT, { jd_text: prep.jd_text.slice(0, 6000) }) }], STRUCTURED_CHAT_OPTIONS)
+      const fit = this.deps.ai.complete(context, [{ role: 'system', content: '你是匹配分析引擎。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_FIT_PROMPT, { jd_text: prep.jd_text.slice(0, 6000), resume_context: resumeText.slice(0, 5000) || '未上传简历', profile_summary: profileSummary }) }], STRUCTURED_CHAT_OPTIONS)
       const [companyReport, jdText, fitText] = await Promise.all([company, jd, fit])
       const jdAnalysis = parseObject(jdText, { role_title: '', required_skills: [], likely_question_dimensions: [] })
       const fitReport = parseObject(fitText, { overall_fit: 0, highlights: [], gaps: [], talking_points: [] })
 
       await this.deps.repository.updatePrepProgress(prepId, task.user_id, '正在生成 HR 提问策略树...')
-      const strategy = parseObject(await this.deps.ai.complete(context, [{ role: 'system', content: '你是面试策略引擎。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_STRATEGY_PROMPT, { role_title: jdAnalysis.role_title || '技术岗位', company_report: companyReport.slice(0, 3000), jd_analysis: json(jdAnalysis).slice(0, 3000), fit_report: json(fitReport).slice(0, 3000), profile_summary: profileSummary.slice(0, 3000) }) }]), { root_nodes: [], nodes: {}, phase_order: [] })
+      const strategy = parseObject(await this.deps.ai.complete(context, [{ role: 'system', content: '你是面试策略引擎。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_STRATEGY_PROMPT, { role_title: jdAnalysis.role_title || '技术岗位', company_report: companyReport.slice(0, 3000), jd_analysis: json(jdAnalysis).slice(0, 3000), fit_report: json(fitReport).slice(0, 3000), profile_summary: profileSummary.slice(0, 3000) }) }], STRUCTURED_CHAT_OPTIONS), { root_nodes: [], nodes: {}, phase_order: [] })
 
       await this.deps.repository.updatePrepProgress(prepId, task.user_id, '正在评估风险路径...')
       const nodes = object(strategy.nodes)
       const riskNodes = Object.entries(nodes).flatMap(([nodeId, raw]) => { const node = object(raw); return ['danger', 'caution'].includes(String(node.risk_level)) ? [{ node_id: nodeId, topic: node.topic || '', risk_level: node.risk_level }] : [] })
       let risk: Record<string, unknown> = { risk_map: [], prep_hints: [], risk_summary: '' }
-      if (riskNodes.length) risk = parseObject(await this.deps.ai.complete(context, [{ role: 'system', content: '你是风险评估引擎。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_RISK_PROMPT, { weak_points: json(Array.isArray(profile.weak_points) ? profile.weak_points.slice(0, 10) : []), gaps: json(Array.isArray(fitReport.gaps) ? fitReport.gaps.slice(0, 10) : []), risk_nodes: json(riskNodes) }) }]), risk)
+      if (riskNodes.length) risk = parseObject(await this.deps.ai.complete(context, [{ role: 'system', content: '你是风险评估引擎。只返回 JSON。' }, { role: 'user', content: fill(COPILOT_RISK_PROMPT, { weak_points: json(Array.isArray(profile.weak_points) ? profile.weak_points.slice(0, 10) : []), gaps: json(Array.isArray(fitReport.gaps) ? fitReport.gaps.slice(0, 10) : []), risk_nodes: json(riskNodes) }) }], STRUCTURED_CHAT_OPTIONS), risk)
       const result = { user_id: task.user_id, jd_text: prep.jd_text, resume_context: resumeText.slice(0, 2000), profile, company_report: companyReport, jd_analysis: jdAnalysis, fit_report: fitReport, question_strategy_tree: strategy, risk_map: Array.isArray(risk.risk_map) ? risk.risk_map : [], risk_summary: String(risk.risk_summary || ''), prep_hints: Array.isArray(risk.prep_hints) ? risk.prep_hints : [], status: 'done', progress: '准备完成', error: '' }
       await this.deps.repository.completePrep(prepId, task.user_id, result)
       const predicted = Array.isArray(fitReport.gaps) ? fitReport.gaps.flatMap((raw) => { const gap = object(raw); return gap.risk === 'high' && typeof gap.point === 'string' ? [gap.point] : [] }) : []

--- a/packages/core/src/copilot/realtime-service.ts
+++ b/packages/core/src/copilot/realtime-service.ts
@@ -2,6 +2,7 @@ import { AppError, AuthenticationError } from '../kernel/errors.ts'
 import { parseJsonResponse } from '../kernel/json.ts'
 import type { RequestContext } from '../kernel/context.ts'
 import { fill } from '../interview/prompts.ts'
+import { STRUCTURED_CHAT_OPTIONS } from '../provider/ports.ts'
 import type { CopilotClientMessage, CopilotConversationTurn, CopilotServerEvent, CopilotSessionState } from './model.ts'
 import type { CopilotDependencies, CopilotRealtimeConnection, CopilotRealtimeUseCases, RealtimeAsrSession } from './ports.ts'
 import { COPILOT_ADVICE_PROMPT, COPILOT_HR_PROFILE_PROMPT, COPILOT_MONITOR_PROMPT } from './prompts.ts'
@@ -114,14 +115,14 @@ class RealtimeConnection implements CopilotRealtimeConnection {
 
   private async hrProfile(turns: CopilotConversationTurn[]): Promise<void> {
     if (turns.length < 3 || this.stopped) return
-    try { const result = parseObject(await this.deps.ai.complete(this.context, [{ role: 'system', content: '只输出 JSON' }, { role: 'user', content: fill(COPILOT_HR_PROFILE_PROMPT, { conversation: conversationText(turns) }) }])); if (result && !this.stopped) await this.emit({ type: 'hr_profile_update', ...result }) } catch { /* background analysis is best effort */ }
+    try { const result = parseObject(await this.deps.ai.complete(this.context, [{ role: 'system', content: '只输出 JSON' }, { role: 'user', content: fill(COPILOT_HR_PROFILE_PROMPT, { conversation: conversationText(turns) }) }], STRUCTURED_CHAT_OPTIONS)); if (result && !this.stopped) await this.emit({ type: 'hr_profile_update', ...result }) } catch { /* background analysis is best effort */ }
   }
 
   private async monitor(turns: CopilotConversationTurn[]): Promise<void> {
     if (!turns.length || this.stopped) return
     const fit = object(this.prep.fit_report); const jd = object(this.prep.jd_analysis); const profile = object(this.prep.profile)
     const skills = items(jd.required_skills).slice(0, 10).map((item) => String(item.skill || JSON.stringify(item))).join('; ') || '无'
-    try { const result = parseObject(await this.deps.ai.complete(this.context, [{ role: 'system', content: '只输出 JSON' }, { role: 'user', content: fill(COPILOT_MONITOR_PROMPT, { conversation: conversationText(turns), required_skills: skills, highlights: summaryPoints(fit.highlights, 5), weak_points: summaryPoints(profile.weak_points, 5) }) }])); if (result && !this.stopped) await this.emit({ type: 'monitor_update', ...result }) } catch { /* background analysis is best effort */ }
+    try { const result = parseObject(await this.deps.ai.complete(this.context, [{ role: 'system', content: '只输出 JSON' }, { role: 'user', content: fill(COPILOT_MONITOR_PROMPT, { conversation: conversationText(turns), required_skills: skills, highlights: summaryPoints(fit.highlights, 5), weak_points: summaryPoints(profile.weak_points, 5) }) }], STRUCTURED_CHAT_OPTIONS)); if (result && !this.stopped) await this.emit({ type: 'monitor_update', ...result }) } catch { /* background analysis is best effort */ }
   }
 
   private async stop(): Promise<void> { this.stopped = true; await this.asr?.stop(); this.asr = undefined; if (this.state) { this.state.status = 'stopped'; await this.persist() }; await this.emit({ type: 'stopped' }) }

--- a/packages/core/src/interview/interview-service.ts
+++ b/packages/core/src/interview/interview-service.ts
@@ -1,6 +1,7 @@
 import type { RequestContext } from '../kernel/context.ts'
 import { AppError, AuthenticationError, ProviderResponseError } from '../kernel/errors.ts'
 import { parseJsonResponse } from '../kernel/json.ts'
+import { STRUCTURED_CHAT_OPTIONS } from '../provider/ports.ts'
 import type { InterviewUseCases, InterviewDependencies } from './ports.ts'
 import type {
   InterviewAnswer,
@@ -29,8 +30,13 @@ function object(value: unknown): Record<string, unknown> {
 }
 
 function questions(value: unknown, limit: number): InterviewQuestion[] {
-  if (!Array.isArray(value)) throw new SyntaxError('Expected JSON array')
-  return value.slice(0, limit).flatMap((item, index) => {
+  const items = Array.isArray(value)
+    ? value
+    : value && typeof value === 'object' && !Array.isArray(value) && Array.isArray((value as Record<string, unknown>).questions)
+      ? (value as { questions: unknown[] }).questions
+      : undefined
+  if (!items) throw new SyntaxError('Expected JSON question array')
+  return items.slice(0, limit).flatMap((item, index) => {
     if (!item || typeof item !== 'object' || Array.isArray(item)) return []
     const source = item as Record<string, unknown>
     const question = typeof source.question === 'string' ? source.question.trim() : ''
@@ -138,7 +144,7 @@ export class InterviewService implements InterviewUseCases {
     const parsed = object(parseJsonResponse(await this.deps.ai.complete(context, [
       { role: 'system', content: '你是 JD 备面分析引擎。只返回 JSON。' },
       { role: 'user', content: fill(JOB_PREVIEW_PROMPT, { company: input.company || '未提供', position: input.position || '未提供', jd_text: jd.slice(0, 6000), resume_context: resumeContext || '未启用简历联动', user_profile: await this.deps.profile.summary(id) }) },
-    ])))
+    ], STRUCTURED_CHAT_OPTIONS)))
     const alignment = objectOrEmpty(parsed.resume_alignment)
     return { preview: {
       company: (input.company || String(parsed.company || '')).trim(),
@@ -165,9 +171,9 @@ export class InterviewService implements InterviewUseCases {
     const preview = input.preview_data || (await this.previewJob(context, input)).preview
     const resumeContext = (input.use_resume ?? true) ? (await this.deps.resume.text(context)).slice(0, 5000) : ''
     const generated = questions(parseJsonResponse(await this.deps.ai.complete(context, [
-      { role: 'system', content: '你是 JD 备面出题引擎。只返回 JSON 数组。' },
+      { role: 'system', content: '你是 JD 备面出题引擎。只返回 JSON 对象，题目放在 questions 数组中。' },
       { role: 'user', content: fill(JOB_QUESTION_PROMPT, { preview: JSON.stringify(preview, null, 2).slice(0, 5000), jd_text: jd.slice(0, 5000), resume_context: resumeContext || '未启用简历联动', user_profile: await this.deps.profile.summary(id) }) },
-    ])), 8)
+    ], STRUCTURED_CHAT_OPTIONS)), 8)
     if (generated.length < 4) throw new AppError('JD 备面出题失败，生成的问题数量不足。请重试。', 500)
     const sessionId = this.deps.ids.next()
     const meta = { company: String(preview.company || input.company || '').trim(), position: String(preview.position || input.position || '').trim() || 'JD 备面', jd_text: jd, use_resume: input.use_resume ?? true, preview }
@@ -191,12 +197,12 @@ export class InterviewService implements InterviewUseCases {
         this.deps.profile.summary(id, input.topic),
       ])
       const messages = [
-        { role: 'system', content: '你是专项训练出题引擎。只返回 JSON 数组。' },
+        { role: 'system', content: '你是专项训练出题引擎。只返回 JSON 对象，题目放在 questions 数组中。' },
         { role: 'user', content: fill(DRILL_QUESTION_PROMPT, { topic_name: topics[input.topic]!.name, num_questions: count, knowledge_context: knowledge, user_profile: profile, high_frequency: highFrequency.slice(0, 4000) || '暂无', recent_questions: recent.map((value) => `- ${value}`).join('\n') || '暂无', divergence }) },
       ] as const
       let generated: InterviewQuestion[] = []
       for (let attempt = 0; attempt < 2 && generated.length !== count; attempt += 1) {
-        const text = await this.deps.ai.complete(context, messages, { maxTokens: topicQuestionMaxTokens(count) })
+        const text = await this.deps.ai.complete(context, messages, { ...STRUCTURED_CHAT_OPTIONS, maxTokens: topicQuestionMaxTokens(count) })
         try { generated = questions(parseJsonResponse(text), count) } catch { generated = [] }
       }
       if (generated.length !== count) throw new ProviderResponseError('模型返回的专项训练题目不完整，已自动重试，请稍后再试或更换模型。')
@@ -305,9 +311,9 @@ export class InterviewService implements InterviewUseCases {
           const topics = await this.deps.knowledgeStore.loadTopics(session.user_id)
           const topicName = topics[session.topic || '']?.name || session.topic || ''
           const references = await this.deps.knowledge.context(context, session.topic || '', session.questions.map((question) => question.question), { topK: 2, charBudget: 8000 })
-          parsed = object(parseJsonResponse(await this.deps.ai.complete(context, [{ role: 'system', content: '你是训练评估引擎。只返回 JSON。' }, { role: 'user', content: fill(DRILL_EVALUATION_PROMPT, { topic_name: topicName, qa_pairs: qaText(session.questions, answers), references }) }])))
+          parsed = object(parseJsonResponse(await this.deps.ai.complete(context, [{ role: 'system', content: '你是训练评估引擎。只返回 JSON。' }, { role: 'user', content: fill(DRILL_EVALUATION_PROMPT, { topic_name: topicName, qa_pairs: qaText(session.questions, answers), references }) }], STRUCTURED_CHAT_OPTIONS)))
         } else {
-          parsed = object(parseJsonResponse(await this.deps.ai.complete(context, [{ role: 'system', content: '你是 JD 备面评估引擎。只返回 JSON。' }, { role: 'user', content: fill(JOB_EVALUATION_PROMPT, { preview: JSON.stringify(session.meta.preview || {}, null, 2).slice(0, 5000), qa_pairs: qaText(session.questions, answers) }) }])))
+          parsed = object(parseJsonResponse(await this.deps.ai.complete(context, [{ role: 'system', content: '你是 JD 备面评估引擎。只返回 JSON。' }, { role: 'user', content: fill(JOB_EVALUATION_PROMPT, { preview: JSON.stringify(session.meta.preview || {}, null, 2).slice(0, 5000), qa_pairs: qaText(session.questions, answers) }) }], STRUCTURED_CHAT_OPTIONS)))
         }
         const scores = Array.isArray(parsed.scores) ? parsed.scores as Array<Record<string, unknown>> : []
         const difficulty = new Map(session.questions.map((question) => [String(question.id), question.difficulty || 3]))

--- a/packages/core/src/interview/prompts.ts
+++ b/packages/core/src/interview/prompts.ts
@@ -52,8 +52,8 @@ export const DRILL_QUESTION_PROMPT = `你是「{topic_name}」领域的技术专
 - 发散度 {divergence}/5；发散度越低越聚焦薄弱与核心概念，越高越多跨场景迁移
 - 难度从 1 到 5 递进，每题只考一个独立知识点
 - 考理解、原理和权衡，不考定义背诵
-- 只返回 JSON 数组，不要解释：
-[{"id":1,"question":"问题","difficulty":2,"focus_area":"知识点"}]`
+- 只返回 JSON 对象，不要解释，题目放在 questions 数组中：
+{"questions":[{"id":1,"question":"问题","difficulty":2,"focus_area":"知识点"}]}`
 
 export const DRILL_EVALUATION_PROMPT = `你是「{topic_name}」领域的技术专家，请逐题评估候选人的回答。参考知识只用于判断核心理解，不要求原文复述。
 
@@ -88,7 +88,7 @@ JD：{jd_text}
 简历：{resume_context}
 历史画像：{user_profile}
 
-只返回 JSON 数组：[{"id":1,"question":"问题","difficulty":3,"focus_area":"考察点","category":"类别","intent":"意图"}]。每题只问一个重点，不要泄露参考答案。`
+只返回 JSON 对象，题目放在 questions 数组中：{"questions":[{"id":1,"question":"问题","difficulty":3,"focus_area":"考察点","category":"类别","intent":"意图"}]}。每题只问一个重点，不要泄露参考答案。`
 
 export const JOB_EVALUATION_PROMPT = `你是 JD 定向面试评估引擎。根据岗位真实招聘标准评估回答。
 

--- a/packages/core/src/profile/profile-service.ts
+++ b/packages/core/src/profile/profile-service.ts
@@ -1,6 +1,7 @@
 import type { RequestContext } from '../kernel/context.ts'
 import { AppError, AuthenticationError } from '../kernel/errors.ts'
 import { parseJsonResponse } from '../kernel/json.ts'
+import { STRUCTURED_CHAT_OPTIONS } from '../provider/ports.ts'
 import type { CandidateProfilePort } from '../interview/ports.ts'
 import type { InterviewSession, TaskRecord } from '../interview/model.ts'
 import { fill } from '../interview/prompts.ts'
@@ -399,7 +400,7 @@ export class ProfileService implements ProfileUseCases, CandidateProfilePort {
       const parsed = parseJsonResponse(await this.deps.ai.complete(this.context(userId, 'consolidation'), [
         { role: 'system', content: '你是模式识别引擎。只返回 JSON。' },
         { role: 'user', content: fill(CONSOLIDATION_PROMPT, { weak_points: formatted }) },
-      ]))
+      ], STRUCTURED_CHAT_OPTIONS))
       patterns = Array.isArray(object(parsed).patterns) ? object(parsed).patterns as unknown[] : []
     } catch { return }
 
@@ -442,7 +443,7 @@ export class ProfileService implements ProfileUseCases, CandidateProfilePort {
     let extraction: Record<string, unknown> | undefined
     for (let attempt = 0; attempt < 2 && !extraction; attempt += 1) {
       try {
-        const parsed = parseJsonResponse(await this.deps.ai.complete(context, [{ role: 'system', content: '你是面试分析引擎。只返回 JSON。' }, { role: 'user', content: fill(EXTRACT_PROMPT, { mode: input.session.mode, topic: input.session.topic || '综合', transcript, scores: JSON.stringify(input.session.scores), existing_behavior_signals: behaviorSummary(before), review: input.session.review || '' }) }]))
+        const parsed = parseJsonResponse(await this.deps.ai.complete(context, [{ role: 'system', content: '你是面试分析引擎。只返回 JSON。' }, { role: 'user', content: fill(EXTRACT_PROMPT, { mode: input.session.mode, topic: input.session.topic || '综合', transcript, scores: JSON.stringify(input.session.scores), existing_behavior_signals: behaviorSummary(before), review: input.session.review || '' }) }], STRUCTURED_CHAT_OPTIONS))
         if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) extraction = parsed
       }
       catch { /* retry once */ }

--- a/packages/core/src/provider/ai-service.ts
+++ b/packages/core/src/provider/ai-service.ts
@@ -5,6 +5,8 @@ import type { PlatformProviderConfig } from './model.ts'
 import type {
   ChatDriverFactory,
   ChatMessage,
+  ChatCompleteOptions,
+  ChatStreamOptions,
   ProviderSettingsRepository,
   QuotaUseCases,
   TextGenerationUseCases,
@@ -28,7 +30,7 @@ export class AiService implements TextGenerationUseCases {
   async complete(
     context: RequestContext,
     messages: readonly ChatMessage[],
-    options?: { maxTokens?: number; temperature?: number },
+    options?: ChatCompleteOptions,
   ): Promise<string> {
     const config = await this.resolved(context)
     await this.quota.check(context.userId, config.source)
@@ -46,7 +48,7 @@ export class AiService implements TextGenerationUseCases {
   async *stream(
     context: RequestContext,
     messages: readonly ChatMessage[],
-    options?: { temperature?: number },
+    options?: ChatStreamOptions,
   ): AsyncIterable<string> {
     const config = await this.resolved(context)
     await this.quota.check(context.userId, config.source)

--- a/packages/core/src/provider/config.ts
+++ b/packages/core/src/provider/config.ts
@@ -32,13 +32,23 @@ export function embeddingModeOf(settings: EmbeddingSettings): 'api' | 'local' {
   return settings.api_base || settings.api_key ? 'api' : 'local'
 }
 
+export function normalizeLlmSettings(settings?: Partial<LlmSettings>): LlmSettings {
+  return {
+    api_base: settings?.api_base || '',
+    api_key: settings?.api_key || '',
+    model: settings?.model || '',
+    temperature: typeof settings?.temperature === 'number' ? settings.temperature : 0.7,
+    compatibility: settings?.compatibility === 'deepseek' ? 'deepseek' : 'generic',
+  }
+}
+
 export function resolveLlmConfig(
   own: LlmSettings | undefined,
   platform: PlatformProviderConfig,
 ): ResolvedLlmConfig {
-  if (own?.api_key && own.model) return { ...own, source: USER_PROVIDER }
+  if (own?.api_key && own.model) return { ...normalizeLlmSettings(own), source: USER_PROVIDER }
   if (platform.llm.api_key && platform.llm.model) {
-    return { ...platform.llm, temperature: 0.7, source: PLATFORM_PROVIDER }
+    return { ...normalizeLlmSettings({ ...platform.llm, temperature: 0.7 }), source: PLATFORM_PROVIDER }
   }
   return { ...emptyLlmSettings(), source: USER_PROVIDER }
 }

--- a/packages/core/src/provider/model.ts
+++ b/packages/core/src/provider/model.ts
@@ -8,11 +8,14 @@ export const DEFAULT_EMBEDDING_BATCH_SIZE = 10
 
 export type ProviderSource = typeof USER_PROVIDER | typeof PLATFORM_PROVIDER
 
+export type LlmCompatibility = 'generic' | 'deepseek'
+
 export type LlmSettings = {
   api_base: string
   api_key: string
   model: string
   temperature: number
+  compatibility: LlmCompatibility
 }
 
 export type EmbeddingSettings = {
@@ -59,7 +62,7 @@ export type SettingsView = {
 export type ResolvedLlmConfig = LlmSettings & { source: ProviderSource }
 export type ResolvedEmbeddingConfig = EmbeddingSettings & { source: ProviderSource }
 
-export const emptyLlmSettings = (): LlmSettings => ({ api_base: '', api_key: '', model: '', temperature: 0.7 })
+export const emptyLlmSettings = (): LlmSettings => ({ api_base: '', api_key: '', model: '', temperature: 0.7, compatibility: 'generic' })
 export const emptyEmbeddingSettings = (): EmbeddingSettings => ({
   backend: '', api_base: '', api_key: '', api_model: '', local_model: '', local_path: '', api_batch_size: DEFAULT_EMBEDDING_BATCH_SIZE,
 })
@@ -69,7 +72,7 @@ export const emptyServiceSettings = (): ServiceSettings => ({
 export const defaultTrainingSettings = (): TrainingSettings => ({ num_questions: 10, divergence: 3 })
 
 export type PlatformProviderConfig = {
-  llm: Pick<LlmSettings, 'api_base' | 'api_key' | 'model'>
+  llm: Pick<LlmSettings, 'api_base' | 'api_key' | 'model'> & { compatibility?: LlmCompatibility }
   embedding: Pick<EmbeddingSettings, 'api_base' | 'api_key' | 'api_model'>
   dailyCallLimit: number
 }

--- a/packages/core/src/provider/ports.ts
+++ b/packages/core/src/provider/ports.ts
@@ -10,6 +10,20 @@ import type {
   ProviderSource,
 } from './model.ts'
 
+export type ChatReasoningEffort = 'low' | 'high' | 'max'
+export type ChatCompleteOptions = {
+  maxTokens?: number
+  temperature?: number
+  jsonMode?: boolean
+  reasoningEffort?: ChatReasoningEffort
+}
+export type ChatStreamOptions = {
+  temperature?: number
+}
+
+/** Options used by calls whose response is parsed as JSON. Providers may ignore provider-specific fields. */
+export const STRUCTURED_CHAT_OPTIONS: ChatCompleteOptions = { jsonMode: true, reasoningEffort: 'low' }
+
 export type StoredProviderSettings = {
   llm?: LlmSettings
   embedding?: EmbeddingSettings
@@ -60,8 +74,8 @@ export type ChatMessage = { role: 'system' | 'user' | 'assistant'; content: stri
 export type ChatResult = { text: string; promptTokens: number; completionTokens: number }
 
 export interface ChatDriver {
-  complete(messages: readonly ChatMessage[], signal: AbortSignal, options?: { maxTokens?: number; temperature?: number }): Promise<ChatResult>
-  stream(messages: readonly ChatMessage[], signal: AbortSignal, options?: { temperature?: number }): AsyncIterable<string>
+  complete(messages: readonly ChatMessage[], signal: AbortSignal, options?: ChatCompleteOptions): Promise<ChatResult>
+  stream(messages: readonly ChatMessage[], signal: AbortSignal, options?: ChatStreamOptions): AsyncIterable<string>
 }
 
 export interface ChatDriverFactory {
@@ -69,8 +83,8 @@ export interface ChatDriverFactory {
 }
 
 export interface TextGenerationUseCases {
-  complete(context: RequestContext, messages: readonly ChatMessage[], options?: { maxTokens?: number; temperature?: number }): Promise<string>
-  stream(context: RequestContext, messages: readonly ChatMessage[], options?: { temperature?: number }): AsyncIterable<string>
+  complete(context: RequestContext, messages: readonly ChatMessage[], options?: ChatCompleteOptions): Promise<string>
+  stream(context: RequestContext, messages: readonly ChatMessage[], options?: ChatStreamOptions): AsyncIterable<string>
 }
 
 export interface EmbeddingDriver {

--- a/packages/core/src/provider/settings-operations.ts
+++ b/packages/core/src/provider/settings-operations.ts
@@ -23,14 +23,19 @@ function message(error: unknown): string {
 function userId(context: RequestContext): string { if (!context.userId) throw new AuthenticationError(); return context.userId }
 
 const LLM_PROBE_MESSAGES = [
-  { role: 'system' as const, content: '你是专项训练出题引擎。只返回 JSON 数组，不要其他内容。' },
-  { role: 'user' as const, content: '请生成 2 道 JavaScript 专项训练题，只返回严格 JSON 数组。每项包含 id、question、difficulty、focus_area，必须完整闭合。' },
+  { role: 'system' as const, content: '你是专项训练出题引擎。只返回 JSON 对象，不要其他内容。' },
+  { role: 'user' as const, content: '请生成 2 道 JavaScript 专项训练题，只返回严格 JSON 对象。格式必须是 {"questions":[{"id":1,"question":"题目","difficulty":3,"focus_area":"考察点"}]}，必须完整闭合。' },
 ]
 
 function validateLlmProbe(text: string): void {
   try {
     const value = parseJsonResponse(text)
-    if (!Array.isArray(value) || value.length !== 2 || !value.every((item) => {
+    const questions = Array.isArray(value)
+      ? value
+      : value && typeof value === 'object' && !Array.isArray(value) && Array.isArray((value as Record<string, unknown>).questions)
+        ? (value as { questions: unknown[] }).questions
+        : undefined
+    if (!questions || questions.length !== 2 || !questions.every((item) => {
       if (!item || typeof item !== 'object' || Array.isArray(item)) return false
       const question = item as Record<string, unknown>
       return typeof question.question === 'string' && question.question.trim().length > 0
@@ -58,7 +63,10 @@ export class SettingsOperationsService implements SettingsOperationsUseCases {
   async testLlm(context: RequestContext, value: LlmSettings): Promise<{ ok: boolean; error?: string }> {
     try {
       if (!value.api_key.trim() || !value.model.trim()) throw new Error('请先填写必填字段')
-      const result = await this.deps.chats.create({ ...value, source: USER_PROVIDER }).complete(LLM_PROBE_MESSAGES, context.signal, { maxTokens: 2048, temperature: 0 })
+      const probeOptions = value.compatibility === 'deepseek'
+        ? { maxTokens: 4096, temperature: 0, jsonMode: true, reasoningEffort: 'low' as const }
+        : { maxTokens: 2048, temperature: 0 }
+      const result = await this.deps.chats.create({ ...value, source: USER_PROVIDER }).complete(LLM_PROBE_MESSAGES, context.signal, probeOptions)
       validateLlmProbe(result.text)
       return { ok: true }
     } catch (error) { return { ok: false, error: message(error) } }

--- a/packages/core/src/provider/settings-service.ts
+++ b/packages/core/src/provider/settings-service.ts
@@ -1,11 +1,10 @@
 import type { AuthPolicy, UserRepository } from '../account/ports.ts'
 import type { RequestContext } from '../kernel/context.ts'
 import { AuthenticationError } from '../kernel/errors.ts'
-import { embeddingTarget, resolveEmbeddingConfig, resolveLlmConfig } from './config.ts'
+import { embeddingTarget, normalizeLlmSettings, resolveEmbeddingConfig, resolveLlmConfig } from './config.ts'
 import {
   defaultTrainingSettings,
   emptyEmbeddingSettings,
-  emptyLlmSettings,
   emptyServiceSettings,
   type PlatformProviderConfig,
   type SettingsView,
@@ -34,7 +33,7 @@ export class SettingsService implements SettingsUseCases {
       this.repository.loadLastReindexAt(userId),
       this.users.findById(userId),
     ])
-    const llm = stored.llm || emptyLlmSettings()
+    const llm = normalizeLlmSettings(stored.llm)
     const embedding = stored.embedding || emptyEmbeddingSettings()
     const resolvedLlm = resolveLlmConfig(stored.llm, this.platform)
     const resolvedEmbedding = resolveEmbeddingConfig(stored.embedding, this.platform)

--- a/packages/core/src/recording/recording-service.ts
+++ b/packages/core/src/recording/recording-service.ts
@@ -3,6 +3,7 @@ import { fill } from '../interview/prompts.ts'
 import { AppError, AuthenticationError } from '../kernel/errors.ts'
 import { parseJsonResponse } from '../kernel/json.ts'
 import type { RequestContext } from '../kernel/context.ts'
+import { STRUCTURED_CHAT_OPTIONS } from '../provider/ports.ts'
 import { formatDualReview, formatSoloReview } from './formatters.ts'
 import type { RecordingAnalyzeInput } from './model.ts'
 import type { RecordingDependencies, RecordingUseCases } from './ports.ts'
@@ -67,7 +68,7 @@ export class RecordingService implements RecordingUseCases {
         const structured = object(parseJsonResponse(await this.deps.ai.complete(request, [
           { role: 'system', content: '你是面试记录分析引擎。只返回 JSON，不要其他内容。' },
           { role: 'user', content: fill(RECORDING_STRUCTURE_PROMPT, { transcript }) },
-        ])))
+        ], STRUCTURED_CHAT_OPTIONS)))
         const pairs = arrayOfObjects(structured.qa_pairs)
         const questions: InterviewQuestion[] = pairs.flatMap((pair, index) => {
           const question = String(pair.question || '').trim()
@@ -80,7 +81,7 @@ export class RecordingService implements RecordingUseCases {
         const evaluated = object(parseJsonResponse(await this.deps.ai.complete(request, [
           { role: 'system', content: '你是面试评估引擎。只返回 JSON，不要其他内容。' },
           { role: 'user', content: fill(RECORDING_DUAL_EVAL_PROMPT, { qa_pairs: qa, profile_summary: await this.deps.profile.summary(session.user_id) }) + contextSuffix(session.meta.company, session.meta.position) },
-        ])))
+        ], STRUCTURED_CHAT_OPTIONS)))
         scores = arrayOfObjects(evaluated.scores)
         for (const score of scores) if (score.difficulty === undefined) score.difficulty = 3
         overall = object(evaluated.overall || {})
@@ -89,7 +90,7 @@ export class RecordingService implements RecordingUseCases {
         const evaluated = object(parseJsonResponse(await this.deps.ai.complete(request, [
           { role: 'system', content: '你是录音评估引擎。只返回 JSON，不要其他内容。' },
           { role: 'user', content: fill(RECORDING_SOLO_EVAL_PROMPT, { transcript, profile_summary: await this.deps.profile.summary(session.user_id) }) + contextSuffix(session.meta.company, session.meta.position) },
-        ])))
+        ], STRUCTURED_CHAT_OPTIONS)))
         const topics = arrayOfObjects(evaluated.topics_covered)
         overall = object(evaluated.overall || {})
         overall.topics_covered = topics

--- a/packages/core/src/resume/resume-service.ts
+++ b/packages/core/src/resume/resume-service.ts
@@ -1,5 +1,6 @@
 import { AppError, AuthenticationError } from '../kernel/errors.ts'
 import { parseJsonResponse } from '../kernel/json.ts'
+import { STRUCTURED_CHAT_OPTIONS } from '../provider/ports.ts'
 import type { RequestContext } from '../kernel/context.ts'
 import type { ResumeDependencies, ResumeUseCases } from './ports.ts'
 
@@ -87,7 +88,7 @@ export class ResumeService implements ResumeUseCases {
     ]
     for (let attempt = 0; attempt < 2; attempt += 1) {
       try {
-        const parsed = parseJsonResponse(await this.deps.ai.complete(context, messages))
+        const parsed = parseJsonResponse(await this.deps.ai.complete(context, messages, STRUCTURED_CHAT_OPTIONS))
         if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return { ok: true as const, parsed }
       } catch (error) {
         if (attempt === 1) throw new AppError('简历解析失败，请重试', 500)

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -7,6 +7,8 @@ import {
   normalizeEmbeddingApiBase,
   type ChatDriver,
   type ChatDriverFactory,
+  type ChatCompleteOptions,
+  type ChatStreamOptions,
   type ChatMessage,
   type EmbeddingDriver,
   type EmbeddingDriverFactory,
@@ -60,7 +62,7 @@ export class OpenAiChatDriverFactory implements ChatDriverFactory {
     const retryDelaysMs = this.options.retryDelaysMs || DEFAULT_EMPTY_COMPLETION_RETRY_DELAYS_MS
     const sleep = this.options.sleep || abortableSleep
     return {
-      async complete(messages: readonly ChatMessage[], signal: AbortSignal, options?: { maxTokens?: number; temperature?: number }) {
+      async complete(messages: readonly ChatMessage[], signal: AbortSignal, options?: ChatCompleteOptions) {
         let promptTokens = 0
         let completionTokens = 0
         for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
@@ -69,7 +71,11 @@ export class OpenAiChatDriverFactory implements ChatDriverFactory {
               model: config.model,
               messages: [...messages],
               temperature: options?.temperature ?? config.temperature,
-              ...(options?.maxTokens === undefined ? {} : { max_tokens: options.maxTokens }),
+              ...(options?.maxTokens === undefined
+                ? (config.compatibility === 'deepseek' && options?.jsonMode ? { max_tokens: 8192 } : {})
+                : { max_tokens: options.maxTokens }),
+              ...(config.compatibility === 'deepseek' && options?.jsonMode ? { response_format: { type: 'json_object' } } : {}),
+              ...(config.compatibility === 'deepseek' && options?.jsonMode && options?.reasoningEffort ? { reasoning_effort: options.reasoningEffort } : {}),
             },
             { signal },
           )
@@ -81,9 +87,14 @@ export class OpenAiChatDriverFactory implements ChatDriverFactory {
         }
         throw new ProviderResponseError('模型服务连续返回空内容，已自动重试，请稍后再试或更换模型。')
       },
-      async *stream(messages: readonly ChatMessage[], signal: AbortSignal, options?: { temperature?: number }) {
+      async *stream(messages: readonly ChatMessage[], signal: AbortSignal, options?: ChatStreamOptions) {
         const response = await client.chat.completions.create(
-          { model: config.model, messages: [...messages], temperature: options?.temperature ?? config.temperature, stream: true },
+          {
+            model: config.model,
+            messages: [...messages],
+            temperature: options?.temperature ?? config.temperature,
+            stream: true,
+          },
           { signal },
         )
         for await (const chunk of response) {

--- a/tests-ts/interview.test.ts
+++ b/tests-ts/interview.test.ts
@@ -8,6 +8,7 @@ import {
   ProfileService,
   ResumeInterviewEngine,
   type CandidateProfilePort,
+  type ChatCompleteOptions,
   type ChatMessage,
   type InterviewDependencies,
   type KnowledgeStore,
@@ -31,9 +32,9 @@ const context: RequestContext = { requestId: 'test', userId: 'user-a', signal: n
 
 class FakeAi implements TextGenerationUseCases {
   calls: ChatMessage[][] = []
-  options: Array<{ maxTokens?: number; temperature?: number } | undefined> = []
+  options: Array<ChatCompleteOptions | undefined> = []
   constructor(private readonly replies: string[]) {}
-  async complete(_context: RequestContext, messages: readonly ChatMessage[], options?: { maxTokens?: number; temperature?: number }): Promise<string> {
+  async complete(_context: RequestContext, messages: readonly ChatMessage[], options?: ChatCompleteOptions): Promise<string> {
     this.calls.push([...messages])
     this.options.push(options)
     const reply = this.replies.shift()

--- a/tests-ts/interview.test.ts
+++ b/tests-ts/interview.test.ts
@@ -232,7 +232,10 @@ describe('interview application service', () => {
     const result = await service.start(context, { mode: 'topic_drill', topic: 'typescript', num_questions: 10 })
     expect(result.questions).toHaveLength(10)
     expect(ai.calls).toHaveLength(2)
-    expect(ai.options).toEqual([{ maxTokens: 5120 }, { maxTokens: 5120 }])
+    expect(ai.options).toEqual([
+      { maxTokens: 5120, jsonMode: true, reasoningEffort: 'low' },
+      { maxTokens: 5120, jsonMode: true, reasoningEffort: 'low' },
+    ])
     sessions.close(); states.close()
   })
 

--- a/tests-ts/providers.test.ts
+++ b/tests-ts/providers.test.ts
@@ -15,7 +15,7 @@ function chatFetch(replies: unknown[], requests: Array<Record<string, unknown>>)
 }
 
 describe('chat provider compatibility', () => {
-  const config = { api_base: 'https://example.test/v1', api_key: 'key', model: 'test-model', temperature: 0.7, source: USER_PROVIDER }
+  const config = { api_base: 'https://example.test/v1', api_key: 'key', model: 'test-model', temperature: 0.7, compatibility: 'generic' as const, source: USER_PROVIDER }
   const valid = completion([{ index: 0, message: { role: 'assistant', content: '[{"id":1,"question":"题目"}]' }, finish_reason: 'stop' }], { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 })
 
   test('retries null choices with backoff and preserves the output limit', async () => {
@@ -50,6 +50,39 @@ describe('chat provider compatibility', () => {
     })
     expect(requests).toHaveLength(3)
     expect(delays).toEqual([10, 20])
+  })
+
+  test('sends DeepSeek-only structured parameters only in DeepSeek mode', async () => {
+    const requests: Array<Record<string, unknown>> = []
+    const factory = new OpenAiChatDriverFactory({ fetch: chatFetch([valid], requests), retryDelaysMs: [], sleep: async () => {} })
+    await factory.create({ ...config, compatibility: 'deepseek' }).complete(
+      [{ role: 'user', content: 'return json' }],
+      new AbortController().signal,
+      { maxTokens: 4096, jsonMode: true, reasoningEffort: 'low' },
+    )
+    expect(requests[0]).toMatchObject({
+      response_format: { type: 'json_object' },
+      reasoning_effort: 'low',
+      max_tokens: 4096,
+    })
+
+    requests.length = 0
+    await factory.create(config).complete(
+      [{ role: 'user', content: 'return json' }],
+      new AbortController().signal,
+      { maxTokens: 4096, jsonMode: true, reasoningEffort: 'low' },
+    )
+    expect(requests[0]?.response_format).toBeUndefined()
+    expect(requests[0]?.reasoning_effort).toBeUndefined()
+
+    requests.length = 0
+    await factory.create({ ...config, compatibility: 'deepseek' }).complete(
+      [{ role: 'user', content: 'answer normally' }],
+      new AbortController().signal,
+      { reasoningEffort: 'low' },
+    )
+    expect(requests[0]?.response_format).toBeUndefined()
+    expect(requests[0]?.reasoning_effort).toBeUndefined()
   })
 })
 

--- a/tests-ts/settings-provider.test.ts
+++ b/tests-ts/settings-provider.test.ts
@@ -34,8 +34,8 @@ describe('provider resolution', () => {
   test('platform fallback is used only when own config is incomplete', () => {
     const platform = { ...emptyPlatform, llm: { api_base: 'https://platform.test/v1', api_key: 'platform-key', model: 'platform-model' } }
     expect(resolveLlmConfig(undefined, platform).source).toBe(PLATFORM_PROVIDER)
-    expect(resolveLlmConfig({ api_base: '', api_key: 'mine', model: '', temperature: 0.7 }, platform).source).toBe(PLATFORM_PROVIDER)
-    expect(resolveLlmConfig({ api_base: '', api_key: 'mine', model: 'my-model', temperature: 0.7 }, platform).source).toBe(USER_PROVIDER)
+    expect(resolveLlmConfig({ api_base: '', api_key: 'mine', model: '', temperature: 0.7, compatibility: 'generic' }, platform).source).toBe(PLATFORM_PROVIDER)
+    expect(resolveLlmConfig({ api_base: '', api_key: 'mine', model: 'my-model', temperature: 0.7, compatibility: 'generic' }, platform).source).toBe(USER_PROVIDER)
   })
 
   test('explicit local embedding is never replaced by platform API', () => {
@@ -125,15 +125,15 @@ describe('settings operations', () => {
     let llmOptions: Record<string, unknown> | undefined
     let embeddingConfig: Record<string, unknown> | undefined
     const service = new SettingsOperationsService({
-      chats: { create(config: Record<string, unknown>) { llmConfig = config; return { async complete(messages: Array<Record<string, unknown>>, _signal: unknown, options: Record<string, unknown>) { llmMessages = messages; llmOptions = options; return { text: JSON.stringify([{ id: 1, question: '闭包是什么？', difficulty: 2, focus_area: '闭包' }, { id: 2, question: '事件循环如何工作？', difficulty: 3, focus_area: '事件循环' }]), promptTokens: 1, completionTokens: 1 } }, async *stream() {} } } },
+      chats: { create(config: Record<string, unknown>) { llmConfig = config; return { async complete(messages: Array<Record<string, unknown>>, _signal: unknown, options: Record<string, unknown>) { llmMessages = messages; llmOptions = options; return { text: JSON.stringify({ questions: [{ id: 1, question: '闭包是什么？', difficulty: 2, focus_area: '闭包' }, { id: 2, question: '事件循环如何工作？', difficulty: 3, focus_area: '事件循环' }] }), promptTokens: 1, completionTokens: 1 } }, async *stream() {} } } },
       embeddingDrivers: { async create(config: Record<string, unknown>) { embeddingConfig = config; return { async embed() { return [Float32Array.from([1])] } } } },
       embeddings: {}, index: {}, vectors: {}, knowledge: {}, personal: {}, profile: {}, settings: {},
     } as never)
     const context = { requestId: 'test', userId: 'user', signal: new AbortController().signal }
-    expect(await service.testLlm(context, { api_base: 'https://submitted.test/v1', api_key: 'submitted-key', model: 'submitted-model', temperature: 0.2 })).toEqual({ ok: true })
+    expect(await service.testLlm(context, { api_base: 'https://submitted.test/v1', api_key: 'submitted-key', model: 'submitted-model', temperature: 0.2, compatibility: 'deepseek' })).toEqual({ ok: true })
     expect(llmConfig).toMatchObject({ api_base: 'https://submitted.test/v1', api_key: 'submitted-key', model: 'submitted-model', source: USER_PROVIDER })
     expect(llmMessages?.map((message) => message.content).join('\n')).toContain('专项训练')
-    expect(llmOptions).toEqual({ maxTokens: 2048, temperature: 0 })
+    expect(llmOptions).toEqual({ maxTokens: 4096, temperature: 0, jsonMode: true, reasoningEffort: 'low' })
     expect(await service.testEmbedding(context, { backend: 'local', api_base: '', api_key: '', api_model: '', local_model: 'Xenova/bge-m3', local_path: '', api_batch_size: 10 })).toEqual({ ok: true })
     expect(embeddingConfig).toMatchObject({ backend: 'local', local_model: 'Xenova/bge-m3', source: USER_PROVIDER })
   })
@@ -145,7 +145,7 @@ describe('settings operations', () => {
     } as never)
     const context = { requestId: 'test', userId: 'user', signal: new AbortController().signal }
 
-    expect(await service.testLlm(context, { api_base: 'https://submitted.test/v1', api_key: 'submitted-key', model: 'submitted-model', temperature: 0.2 })).toEqual({
+    expect(await service.testLlm(context, { api_base: 'https://submitted.test/v1', api_key: 'submitted-key', model: 'submitted-model', temperature: 0.2, compatibility: 'generic' })).toEqual({
       ok: false,
       error: '模型已连接，但未返回完整的专项训练结构化结果；请换用支持长文本 JSON 输出的模型。',
     })

--- a/tests-ts/task-queue.test.ts
+++ b/tests-ts/task-queue.test.ts
@@ -164,7 +164,8 @@ describe('persistent task queue leases', () => {
     await repository.upsert({ taskId: 'heartbeat', userId: 'user-a', type: 'review', payload: {} })
 
     const gate = deferred()
-    const queue = new PersistentTaskQueue(repository, { owner: 'live-worker', leaseDurationMs: 80, heartbeatIntervalMs: 10 })
+    const leaseDurationMs = 2_000
+    const queue = new PersistentTaskQueue(repository, { owner: 'live-worker', leaseDurationMs, heartbeatIntervalMs: 100 })
     queue.register('review', async () => {
       await gate.promise
       return { ok: true }
@@ -172,12 +173,12 @@ describe('persistent task queue leases', () => {
     await queue.start()
     await waitFor(async () => (await repository.get('heartbeat', 'user-a'))?.status === 'running')
     const initialExpiry = Date.parse((await repository.get('heartbeat', 'user-a'))!.lease_expires_at!)
-    await waitFor(() => Date.now() > initialExpiry + 20)
+    await waitFor(() => Date.now() > initialExpiry + 20, leaseDurationMs + 1_000)
 
     const renewed = await repository.get('heartbeat', 'user-a')
     expect(Date.parse(renewed!.lease_expires_at!)).toBeGreaterThan(initialExpiry)
     expect(Date.parse(renewed!.lease_expires_at!)).toBeGreaterThan(Date.now())
-    expect(await competitor.claim('heartbeat', 'user-a', { owner: 'other-worker', durationMs: 80 })).toBeUndefined()
+    expect(await competitor.claim('heartbeat', 'user-a', { owner: 'other-worker', durationMs: leaseDurationMs })).toBeUndefined()
 
     gate.resolve()
     await waitFor(async () => (await repository.get('heartbeat', 'user-a'))?.status === 'done')


### PR DESCRIPTION
## 背景

当前使用 DeepSeek V4 配置 TechSpar 时，首次初始化阶段的 LLM 连接测试无法返回完整的专项训练结构化结果，导致用户无法通过模型校验，也就无法进入后台。

原因是初始化探测请求需要模型返回完整 JSON，而 DeepSeek V4 对 JSON 对象输出和推理参数有特定要求。现有通用 OpenAI 兼容请求没有针对这些要求进行适配。

## 变更内容

本 PR 为 LLM 增加 DeepSeek V4 兼容模式：

- 初始化探测请求在 DeepSeek 模式下启用 JSON 对象输出；
- 使用低推理参数，降低结构化响应被截断的概率；
- 结构化请求统一使用 JSON 对象格式，并兼容旧版 JSON 数组响应；
- 简历解析、专项出题、JD 分析、复盘和 Copilot 等结构化场景统一适配；
- 通用 OpenAI 兼容模式不会发送 DeepSeek 专属字段；
- 配置页面增加兼容模式选择，并保留旧配置默认行为。

修复后，使用 DeepSeek 配置的用户可以正常完成首次 LLM 校验并进入后台。

## 验证

- `bun test tests-ts`：112 个测试全部通过；
- TypeScript 类型检查通过；
- 前端 ESLint 与 Vite 构建通过；
- 已重新生成 OpenAPI 和前端 API 类型文件。
<img width="2880" height="1556" alt="c2575b59-de31-4477-aeca-933703c8e21b" src="https://github.com/user-attachments/assets/e4021b2d-4c0e-43a1-9cbb-70679ee3e2c1" />
