### PR TITLE
fix(quota): 修复不同时间格式导致的 token 配额统计错误

### DIFF
--- a/packages/db/src/usage-repository.ts
+++ b/packages/db/src/usage-repository.ts
@@ -51,9 +51,10 @@ export class BunUsageRepository implements UsageRepository {
   }
 
   async platformTokensSince(userId: string, since: string): Promise<number> {
+    // CURRENT_TIMESTAMP uses SQLite's format, while quota windows use ISO-8601.
     const row = this.sqlite.query<{ total: number | null }, { $userId: string; $since: string }>(`
       SELECT SUM(prompt_tokens + completion_tokens) AS total FROM llm_usage
-      WHERE user_id = $userId AND source = 'platform' AND created_at >= $since
+      WHERE user_id = $userId AND source = 'platform' AND julianday(created_at) >= julianday($since)
     `).get({ $userId: userId, $since: since })
     return row?.total || 0
   }

--- a/packages/db/src/usage-repository.ts
+++ b/packages/db/src/usage-repository.ts
@@ -51,10 +51,14 @@ export class BunUsageRepository implements UsageRepository {
   }
 
   async platformTokensSince(userId: string, since: string): Promise<number> {
-    // CURRENT_TIMESTAMP uses SQLite's format, while quota windows use ISO-8601.
+    // Use an indexable coarse bound before the exact comparison. CURRENT_TIMESTAMP
+    // uses SQLite's format, while quota windows use ISO-8601.
     const row = this.sqlite.query<{ total: number | null }, { $userId: string; $since: string }>(`
       SELECT SUM(prompt_tokens + completion_tokens) AS total FROM llm_usage
-      WHERE user_id = $userId AND source = 'platform' AND julianday(created_at) >= julianday($since)
+      WHERE user_id = $userId
+        AND source = 'platform'
+        AND created_at >= datetime($since)
+        AND julianday(created_at) >= julianday($since)
     `).get({ $userId: userId, $since: since })
     return row?.total || 0
   }

--- a/tests-ts/usage-repository.test.ts
+++ b/tests-ts/usage-repository.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { BunUsageRepository } from '@techspar/db'
+
+const directories: string[] = []
+
+async function databasePath(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'techspar-usage-'))
+  directories.push(directory)
+  return join(directory, 'techspar.db')
+}
+
+afterEach(async () => {
+  while (directories.length) await rm(directories.pop()!, { recursive: true, force: true })
+})
+
+describe('usage repository quota windows', () => {
+  test('counts SQLite timestamps against ISO window boundaries', async () => {
+    const path = await databasePath()
+    const repository = new BunUsageRepository(path)
+    repository.initialize()
+
+    try {
+      await repository.record({ userId: 'user-a', source: 'platform', model: 'model-a', promptTokens: 500, completionTokens: 200 })
+      await repository.record({ userId: 'user-a', source: 'platform', model: 'model-a', promptTokens: 10, completionTokens: 20 })
+      await repository.record({ userId: 'user-a', source: 'user', model: 'model-b', promptTokens: 100, completionTokens: 50 })
+
+      const database = new Database(path)
+      try {
+        database.exec(`
+          UPDATE llm_usage
+          SET created_at = CASE id
+            WHEN 1 THEN '2026-08-15 12:00:00'
+            WHEN 2 THEN '2026-08-15 10:00:00'
+            WHEN 3 THEN '2026-08-15 12:00:00'
+          END
+        `)
+      } finally {
+        database.close()
+      }
+
+      // created_at uses SQLite's space-separated format, while subscription
+      // and monthly quota starts are passed in ISO-8601 format.
+      expect(await repository.platformTokensSince('user-a', '2026-08-15T11:00:00.000Z')).toBe(700)
+      expect(await repository.platformTokensSince('other-user', '2026-08-15T11:00:00.000Z')).toBe(0)
+    } finally {
+      repository.close()
+    }
+  })
+})

--- a/tests-ts/usage-repository.test.ts
+++ b/tests-ts/usage-repository.test.ts
@@ -27,6 +27,7 @@ describe('usage repository quota windows', () => {
       await repository.record({ userId: 'user-a', source: 'platform', model: 'model-a', promptTokens: 500, completionTokens: 200 })
       await repository.record({ userId: 'user-a', source: 'platform', model: 'model-a', promptTokens: 10, completionTokens: 20 })
       await repository.record({ userId: 'user-a', source: 'user', model: 'model-b', promptTokens: 100, completionTokens: 50 })
+      await repository.record({ userId: 'user-a', source: 'platform', model: 'model-a', promptTokens: 1, completionTokens: 2 })
 
       const database = new Database(path)
       try {
@@ -36,6 +37,7 @@ describe('usage repository quota windows', () => {
             WHEN 1 THEN '2026-08-15 12:00:00'
             WHEN 2 THEN '2026-08-15 10:00:00'
             WHEN 3 THEN '2026-08-15 12:00:00'
+            WHEN 4 THEN '2026-08-15 11:00:00'
           END
         `)
       } finally {
@@ -44,7 +46,8 @@ describe('usage repository quota windows', () => {
 
       // created_at uses SQLite's space-separated format, while subscription
       // and monthly quota starts are passed in ISO-8601 format.
-      expect(await repository.platformTokensSince('user-a', '2026-08-15T11:00:00.000Z')).toBe(700)
+      expect(await repository.platformTokensSince('user-a', '2026-08-15T11:00:00.000Z')).toBe(703)
+      expect(await repository.platformTokensSince('user-a', '2026-08-15T11:00:00.500Z')).toBe(700)
       expect(await repository.platformTokensSince('other-user', '2026-08-15T11:00:00.000Z')).toBe(0)
     } finally {
       repository.close()


### PR DESCRIPTION
## 动机

平台 token 配额统计存在时间比较错误，可能导致订阅用户和月度 token 配额的已用额度被低估。

## 问题

`llm_usage.created_at` 使用 SQLite 的 `CURRENT_TIMESTAMP` 默认值，保存格式类似：

```text
2026-08-15 12:00:00
```

订阅起始时间和月度配额起始时间则来自 JavaScript 的 `Date.toISOString()`，格式类似：

```text
2026-08-15T11:00:00.000Z
```

原查询直接使用：

```sql
created_at >= $since
```

由于两者都是 `TEXT`，SQLite 执行的是字符串比较。同一天内，空格的排序位置早于 `T`，因此实际发生在窗口起点之后的记录可能被错误排除，导致 token 使用量统计偏低。

## 变更内容

将时间窗口筛选改为“索引下界 + 精确时间比较”两步：

```sql
created_at >= datetime($since)
AND julianday(created_at) >= julianday($since)
```

- `datetime($since)` 将 ISO-8601 窗口起点转换为 SQLite 的时间格式，并保留 `(user_id, source, created_at)` 索引的时间范围过滤能力；
- `julianday(...)` 再进行日期语义比较，正确处理 SQLite 默认时间格式、ISO-8601 格式以及毫秒边界。

本次修复：

- 不修改数据库结构；
- 不修改历史数据；
- 不修改 API 或配置；
- 不影响 user provider 的用量统计；
- 只修复 platform token 时间窗口的比较逻辑。

## 回归测试

新增真实 SQLite 回归测试，覆盖：

- 时间窗口内的 platform 用量会被计入；
- 时间窗口之前的 platform 用量不会被计入；
- 恰好位于窗口起点的记录会被计入；
- 窗口起点包含毫秒时，起点之前的记录不会被误计入；
- user provider 用量不会混入 platform 配额；
- 其他用户的用量不会被计算。

## 验证

- `bun test tests-ts`：116 个测试通过，720 个断言通过；
- `bun run typecheck`：通过；
- `bun run typecheck:node`：通过；
- `bun run check:boundaries`：通过；
- `git diff --check`：通过；
- SQLite `EXPLAIN QUERY PLAN`：确认查询仍可利用 `created_at` 的索引范围过滤。