### PR TITLE
chore(release): prepare v0.3.2

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techspar/api",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techspar/desktop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TechSpar AI technical interview training desktop client",
   "author": "TechSpar",
   "private": true,

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "apps/api": {
       "name": "@techspar/api",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@hono/zod-openapi": "^1.1.5",
         "@techspar/contracts": "workspace:*",
@@ -35,7 +35,7 @@
     },
     "apps/desktop": {
       "name": "@techspar/desktop",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "electron": "43.4.1",
         "electron-builder": "26.15.7",
@@ -111,18 +111,18 @@
     },
     "packages/contracts": {
       "name": "@techspar/contracts",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "zod": "^4.3.6",
       },
     },
     "packages/core": {
       "name": "@techspar/core",
-      "version": "0.3.1",
+      "version": "0.3.2",
     },
     "packages/db": {
       "name": "@techspar/db",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@techspar/core": "workspace:*",
         "drizzle-orm": "^0.44.7",
@@ -130,7 +130,7 @@
     },
     "packages/platform": {
       "name": "@techspar/platform",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@techspar/core": "workspace:*",
         "bcryptjs": "^3.0.3",
@@ -141,7 +141,7 @@
     },
     "packages/providers": {
       "name": "@techspar/providers",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@techspar/core": "workspace:*",
@@ -150,7 +150,7 @@
     },
     "packages/testing": {
       "name": "@techspar/testing",
-      "version": "0.3.1",
+      "version": "0.3.2",
     },
   },
   "packages": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@
 - [Hono / TypeScript / Electron 迁移实施记录](hono-typescript-migration.md)
 - [TypeScript 迁移完整性收尾清单](typescript-migration-closeout.md)
 - [TypeScript 后端架构](typescript-backend-architecture.md)
+- [v0.3.2 发布说明](releases/v0.3.2.md)
 - [v0.3.1 发布说明](releases/v0.3.1.md)
 - [v0.3.0 发布说明](releases/v0.3.0.md)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,5 +20,6 @@
 * [Hono / TypeScript / Electron 迁移实施记录](hono-typescript-migration.md)
 * [TypeScript 迁移完整性收尾清单](typescript-migration-closeout.md)
 * [TypeScript 后端架构](typescript-backend-architecture.md)
+* [v0.3.2 发布说明](releases/v0.3.2.md)
 * [v0.3.1 发布说明](releases/v0.3.1.md)
 * [v0.3.0 发布说明](releases/v0.3.0.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,7 +32,7 @@ bun run dist:desktop:win-x64   # Windows x64
 
 Electron 使用操作系统标准应用数据目录保存 SQLite、用户文件、模型缓存及每次安装随机生成的 JWT/声纹加密密钥。不要手工把服务端 `data/` 与桌面目录双向同步；迁移数据请使用产品内的导出/导入。
 
-v0.3.1 提供 macOS arm64 和 Windows x64 发行包。当前公开包没有商业签名，macOS 还没有 notarization，安装时可能出现 Gatekeeper 或 SmartScreen 提示；安装与启动仍应在对应目标平台验收。
+v0.3.2 提供 macOS arm64 和 Windows x64 发行包。当前公开包没有商业签名，macOS 还没有 notarization，安装时可能出现 Gatekeeper 或 SmartScreen 提示；安装与启动仍应在对应目标平台验收。
 
 后续版本由 tag 驱动：根 `package.json` 与桌面包版本一致后推送同名 `vX.Y.Z` tag，GitHub Actions 会校验版本、分别构建 macOS arm64 和 Windows x64 包、生成 `SHA256SUMS.txt` 并发布到 Releases。未配置证书时仍会生成未签名包；配置仓库 secrets 后可启用 Apple/Windows 签名及 macOS 公证。
 

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -1,0 +1,42 @@
+# TechSpar v0.3.2
+
+v0.3.2 是 v0.3.1 之后的桌面维护版本，集中发布已经进入 `main`、但旧安装包尚未包含的稳定性、Provider 兼容和请求契约修复。桌面包继续内置 Electron、Web 前端、编译后的 Bun/Hono sidecar 与 ONNX Runtime，最终用户不需要另行安装 Bun、Node.js、Python、PyTorch 或 pip。
+
+## 下载
+
+- macOS Apple Silicon：`TechSpar-0.3.2-mac-arm64.dmg`（推荐）或 `TechSpar-0.3.2-mac-arm64.zip`。
+- Windows x64：`TechSpar-0.3.2-win-x64.exe`（NSIS 安装包）。
+- 完整性校验：同一 Release 中的 `SHA256SUMS.txt`。
+
+## 重点修复
+
+- 修复桌面端读取已保存 PDF 简历时把 Node `Buffer` 传给 PDF.js、导致解析被拒绝的问题；存储边界现在统一返回普通 `Uint8Array`。
+- 修复面试自评把界面值 `high` / `low` 原样提交、触发 API `confidence` 数字字段校验失败的问题；所有答题请求统一经过生成契约约束的序列化边界。
+- 修复桌面 sidecar 使用 `exit` 事件过早判定进程结束的问题，改为等待 stdio 关闭后的 `close` 事件，避免遗漏最后的错误输出与退出状态。
+- 加固 OpenAI-compatible Provider：空响应会短暂重试并给出明确的 502 错误；结构化输出会校验实际题目数量；增加 DeepSeek JSON / reasoning 兼容参数。
+- 修复设置页被密码管理器误识别、往 API 配置框自动填邮箱或密码的问题；平台 Key 与用户 Key 改为显式选择，并清楚显示当前生效来源。
+- 修复流式 LLM 请求漏记用量、缓存命中量未记录、订阅时间格式导致 token 汇总错误，以及续费额度累计口径错误。
+- 修复窄屏下领域复盘卡片排版，并补齐前端请求体、OpenAPI 与可空字段的契约防护。
+
+## 托管与自部署说明
+
+- 托管版新增可选的订阅、额度和爱发电订单扩展；未配置 `TECHSPAR_EXTENSIONS` 的自部署与桌面版不会加载付费相关路由。
+- 用户自己的 LLM / Embedding Key 仍按用户隔离；配置平台共享 Key 时，已填写个人 Key 的用户继续优先使用自己的配置。
+- v0.3.2 不改变桌面端现有数据目录，退出旧版本后可直接覆盖安装，SQLite、用户文件和本地模型缓存会继续保留。
+
+## 升级
+
+1. 完全退出正在运行的 TechSpar v0.3.1。
+2. 下载对应平台的 v0.3.2 安装包，并可使用 `SHA256SUMS.txt` 校验完整性。
+3. 直接安装 v0.3.2；不要同时启动旧 Python 版或让两个版本写同一份数据目录。
+4. 首次打开后建议验证简历 PDF、面试提交、设置页 Provider 选择和一次完整训练流程。
+
+## 发布验证
+
+- `v0.3.2` tag 必须指向受保护 `main` 上的版本准备提交。
+- 发布前执行完整 `bun run check` 与 `bun scripts/verify-release-version.ts v0.3.2`。
+- GitHub Actions 分别在 macOS arm64 和 Windows x64 runner 上构建安装包，并生成 `SHA256SUMS.txt`。
+
+## 安装与验收边界
+
+当前公开包没有 Apple Developer ID 或 Windows Authenticode 商业签名，因此 Gatekeeper 或 SmartScreen 可能显示安全提示。自动发布流程会分别在 macOS 和 Windows runner 上构建目标平台安装包；真实安装与启动仍建议在对应目标平台验收。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techspar",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.14",

--- a/packages/contracts/openapi.json
+++ b/packages/contracts/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "TechSpar",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "components": {
     "schemas": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techspar/contracts",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techspar/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techspar/db",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techspar/platform",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techspar/providers",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@techspar/core": "workspace:*",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techspar/testing",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- bump all workspace and OpenAPI versions to 0.3.2
- add v0.3.2 desktop release notes and documentation links
- preserve the unsigned-package and target-platform acceptance boundary

## Verification
- `bun run check` (all code checks passed; initial Electron download was blocked by sandbox DNS)
- `bun run check:desktop` (rerun with network access, passed)
- `bun run smoke:desktop` (passed; appVersion 0.3.2)
- `bun scripts/verify-release-version.ts v0.3.2`
- `git diff --check`