### PR TITLE
fix: harden JD preview handling for provider response variants

### DIFF
--- a/apps/api/src/entry.bun.ts
+++ b/apps/api/src/entry.bun.ts
@@ -45,6 +45,7 @@ import { DashScopeLongAsrDriver, DashScopeRealtimeAsrFactory, DashScopeShortAsrD
 import { createBunWebSocket } from 'hono/bun'
 import { createApp } from './app.ts'
 import { loadExtensions } from './extensions.ts'
+import { withLongRequestTimeout } from './server-options.ts'
 
 const config = loadConfig()
 mkdirSync(dirname(config.dbPath), { recursive: true })
@@ -141,6 +142,6 @@ await taskQueue.start()
 const { upgradeWebSocket, websocket } = createBunWebSocket()
 const app = createApp({ auth, registration, settings, settingsOperations, quota, tokens, knowledge, resume, interview, profile, personalAgent, migration, recording, copilotPrep, copilotRealtime, websocketUpgrade: upgradeWebSocket, voiceprint, extendRoutes: (instance) => extensions.routes?.(instance, extensionContext), webDir: config.webDir })
 
-const server = Bun.serve({ hostname: config.host, port: config.port, fetch: app.fetch, websocket })
+const server = Bun.serve(withLongRequestTimeout({ hostname: config.host, port: config.port, fetch: app.fetch, websocket }))
 console.log(JSON.stringify({ event: 'techspar:ready', host: config.host, port: server.port }))
 for (const signal of ['SIGINT', 'SIGTERM'] as const) process.once(signal, () => { void server.stop(true).finally(() => process.exit(0)) })

--- a/apps/api/src/server-options.test.ts
+++ b/apps/api/src/server-options.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'bun:test'
+import { withLongRequestTimeout } from './server-options.ts'
+
+test('configures Bun for long-running model requests', () => {
+  const options = withLongRequestTimeout({ hostname: '127.0.0.1', port: 0 })
+  expect(options).toMatchObject({ idleTimeout: 255 })
+})

--- a/apps/api/src/server-options.ts
+++ b/apps/api/src/server-options.ts
@@ -1,0 +1,3 @@
+export function withLongRequestTimeout<T extends object>(options: T): T & { idleTimeout: 255 } {
+  return { ...options, idleTimeout: 255 }
+}

--- a/frontend/src/lib/jobPrepDraft.ts
+++ b/frontend/src/lib/jobPrepDraft.ts
@@ -1,0 +1,21 @@
+export function sanitizeJobPrepDraft(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const draft = value as Record<string, unknown>
+  const preview = draft.preview
+  if (!preview || typeof preview !== 'object' || Array.isArray(preview)) return draft
+  const record = preview as Record<string, unknown>
+  const alignment = record.resume_alignment && typeof record.resume_alignment === 'object' && !Array.isArray(record.resume_alignment)
+    ? record.resume_alignment as Record<string, unknown>
+    : {}
+  const strings = (items: unknown) => !Array.isArray(items) || items.every((item) => typeof item === 'string')
+  const objects = (items: unknown, valid: (item: Record<string, unknown>) => boolean) => !Array.isArray(items) || items.every((item) => Boolean(item) && typeof item === 'object' && !Array.isArray(item) && valid(item as Record<string, unknown>))
+  const renderable = (record.role_summary === undefined || typeof record.role_summary === 'string')
+    && (alignment.fit_assessment === undefined || typeof alignment.fit_assessment === 'string')
+    && strings(record.prep_priorities)
+    && strings(alignment.risk_gaps)
+    && strings(alignment.matching_evidence)
+    && objects(record.focus_areas, (item) => typeof item.area === 'string' && (item.reason === undefined || typeof item.reason === 'string'))
+    && objects(record.likely_question_groups, (item) => typeof item.title === 'string' && strings(item.sample_questions))
+    && objects(alignment.recommended_stories, (item) => typeof item.project === 'string' && (item.reason === undefined || typeof item.reason === 'string'))
+  return renderable ? draft : { ...draft, preview: null, previewSignature: '' }
+}

--- a/frontend/src/pages/JobPrep.tsx
+++ b/frontend/src/pages/JobPrep.tsx
@@ -17,6 +17,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { sanitizeJobPrepDraft } from "@/lib/jobPrepDraft";
 
 interface JobPrepProps {
   embedded?: boolean;
@@ -86,7 +87,7 @@ const DRAFT_KEY = "jobprep-draft";
 function loadDraft(): Partial<JobPrepDraft> {
   try {
     const raw = localStorage.getItem(DRAFT_KEY);
-    return raw ? JSON.parse(raw) as Partial<JobPrepDraft> : {};
+    return raw ? sanitizeJobPrepDraft(JSON.parse(raw)) as Partial<JobPrepDraft> : {};
   } catch {
     return {};
   }

--- a/packages/core/src/interview/interview-service.ts
+++ b/packages/core/src/interview/interview-service.ts
@@ -123,6 +123,88 @@ function objectOrEmpty(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
+function text(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number') return String(value)
+  if (Array.isArray(value)) return value.map(text).filter(Boolean).join('；')
+  if (value && typeof value === 'object') return Object.values(value as Record<string, unknown>).map(text).filter(Boolean).join('；')
+  return ''
+}
+
+function textList(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(text).filter(Boolean) : []
+}
+
+function joined(value: unknown): string {
+  return textList(value).join('；')
+}
+
+function normalizeFocusAreas(value: unknown): Array<{ area: string; priority: string; reason: string }> {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => {
+    const record = objectOrEmpty(item)
+    return {
+      area: text(record.area || record.topic || record.name),
+      priority: text(record.priority || record.importance),
+      reason: text(record.reason) || joined(record.expected_capabilities),
+    }
+  }).filter((item) => item.area)
+}
+
+function normalizePriorities(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => {
+    if (typeof item === 'string') return item.trim()
+    const record = objectOrEmpty(item)
+    const topic = text(record.topic || record.title)
+    const actions = joined(record.actions)
+    return [topic, actions].filter(Boolean).join('：')
+  }).filter(Boolean)
+}
+
+function normalizeQuestionGroups(value: unknown): Array<{ title: string; reason: string; sample_questions: string[] }> {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => {
+    const record = objectOrEmpty(item)
+    return {
+      title: text(record.title || record.group),
+      reason: text(record.reason),
+      sample_questions: textList(record.sample_questions || record.questions),
+    }
+  }).filter((item) => item.title)
+}
+
+function normalizeEvidence(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => {
+    if (typeof item === 'string') return item.trim()
+    const record = objectOrEmpty(item)
+    const evidence = text(record.evidence || record.description || record.item)
+    const relevance = text(record.relevance)
+    return relevance ? `${evidence}（${relevance}）` : evidence
+  }).filter(Boolean)
+}
+
+function normalizeRiskGaps(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => {
+    if (typeof item === 'string') return item.trim()
+    const record = objectOrEmpty(item)
+    return [text(record.gap || record.topic), text(record.reason)].filter(Boolean).join('：')
+  }).filter(Boolean)
+}
+
+function normalizeStories(value: unknown): Array<{ project: string; reason: string }> {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => {
+    const record = objectOrEmpty(item)
+    return {
+      project: text(record.project || record.story),
+      reason: text(record.reason) || joined(record.evidence_to_prepare),
+    }
+  }).filter((item) => item.project)
+}
+
 function userId(context: RequestContext): string {
   if (!context.userId) throw new AuthenticationError()
   return context.userId
@@ -149,16 +231,16 @@ export class InterviewService implements InterviewUseCases {
     return { preview: {
       company: (input.company || String(parsed.company || '')).trim(),
       position: (input.position || String(parsed.position || '')).trim(),
-      role_summary: String(parsed.role_summary || '').trim(),
-      focus_areas: Array.isArray(parsed.focus_areas) ? parsed.focus_areas : [],
-      likely_question_groups: Array.isArray(parsed.likely_question_groups) ? parsed.likely_question_groups : [],
+      role_summary: text(parsed.role_summary),
+      focus_areas: normalizeFocusAreas(parsed.focus_areas),
+      likely_question_groups: normalizeQuestionGroups(parsed.likely_question_groups),
       resume_alignment: {
-        resume_used: Boolean(useResume && resumeContext), fit_assessment: String(alignment.fit_assessment || '').trim(),
-        matching_evidence: Array.isArray(alignment.matching_evidence) ? alignment.matching_evidence : [],
-        risk_gaps: Array.isArray(alignment.risk_gaps) ? alignment.risk_gaps : [],
-        recommended_stories: Array.isArray(alignment.recommended_stories) ? alignment.recommended_stories : [],
+        resume_used: Boolean(useResume && resumeContext), fit_assessment: text(alignment.fit_assessment),
+        matching_evidence: normalizeEvidence(alignment.matching_evidence),
+        risk_gaps: normalizeRiskGaps(alignment.risk_gaps),
+        recommended_stories: normalizeStories(alignment.recommended_stories),
       },
-      prep_priorities: Array.isArray(parsed.prep_priorities) ? parsed.prep_priorities : [],
+      prep_priorities: normalizePriorities(parsed.prep_priorities),
       question_blueprint: Array.isArray(parsed.question_blueprint) ? parsed.question_blueprint : [],
       jd_excerpt: jd.slice(0, 1500),
     } }

--- a/tests-ts/interview.test.ts
+++ b/tests-ts/interview.test.ts
@@ -172,6 +172,47 @@ describe('resume interview state machine', () => {
 })
 
 describe('interview application service', () => {
+  test('normalizes structured JD preview fields returned by the model', async () => {
+    const path = await databasePath()
+    const sessions = new BunInterviewSessionRepository(path); sessions.initialize()
+    const states = new BunResumeInterviewStateRepository(path); states.initialize()
+    const ai = new FakeAi([JSON.stringify({
+      company: '跨越速运',
+      position: '高级 Java 工程师',
+      role_summary: { overview: '负责物流核心系统开发', level: '高级岗位' },
+      focus_areas: [{ area: 'Java', importance: '高', expected_capabilities: ['JVM 调优', '并发编程'] }],
+      prep_priorities: [{ priority: 1, topic: '分布式系统', actions: ['准备高并发案例', '复习一致性方案'] }],
+      likely_question_groups: [{ group: '系统设计', questions: ['如何设计物流订单系统？'] }],
+      resume_alignment: {
+        resume_used: true,
+        fit_assessment: { conclusion: '基本匹配', basis: ['Java 经验吻合', '物流经验不足'] },
+        matching_evidence: [{ evidence: '有 Java 项目经验', relevance: '高' }],
+        risk_gaps: [{ gap: '缺少物流经验', reason: '简历未体现物流行业项目' }],
+        recommended_stories: [{ story: '订单系统改造', evidence_to_prepare: ['吞吐量提升', '故障率下降'] }],
+      },
+    })])
+    const service = new InterviewService(interviewDependencies({ sessions, states, ai }))
+
+    const result = await service.previewJob(context, {
+      jd_text: '负责物流核心系统设计开发，要求精通 Java、MySQL、Redis、消息队列、微服务和分布式系统，具备高并发项目经验。',
+      use_resume: true,
+    })
+    sessions.close(); states.close()
+
+    expect(result.preview).toMatchObject({
+      role_summary: '负责物流核心系统开发；高级岗位',
+      focus_areas: [{ area: 'Java', priority: '高', reason: 'JVM 调优；并发编程' }],
+      prep_priorities: ['分布式系统：准备高并发案例；复习一致性方案'],
+      likely_question_groups: [{ title: '系统设计', reason: '', sample_questions: ['如何设计物流订单系统？'] }],
+      resume_alignment: {
+        fit_assessment: '基本匹配；Java 经验吻合；物流经验不足',
+        matching_evidence: ['有 Java 项目经验（高）'],
+        risk_gaps: ['缺少物流经验：简历未体现物流行业项目'],
+        recommended_stories: [{ project: '订单系统改造', reason: '吞吐量提升；故障率下降' }],
+      },
+    })
+  })
+
   test('starts resume sessions with durable state and metadata', async () => {
     const path = await databasePath()
     const sessions = new BunInterviewSessionRepository(path); sessions.initialize()

--- a/tests-ts/job-prep-draft.test.ts
+++ b/tests-ts/job-prep-draft.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import { sanitizeJobPrepDraft } from '../frontend/src/lib/jobPrepDraft.ts'
+
+describe('job prep draft compatibility', () => {
+  test('drops an unrenderable model preview while preserving the JD inputs', () => {
+    const draft = sanitizeJobPrepDraft({
+      company: '跨越速运',
+      position: '高级 Java 工程师',
+      jdText: '完整岗位描述',
+      previewSignature: 'old-signature',
+      preview: {
+        prep_priorities: [{ priority: 1, topic: '分布式系统', actions: ['准备项目案例'] }],
+      },
+    })
+
+    expect(draft).toEqual({
+      company: '跨越速运',
+      position: '高级 Java 工程师',
+      jdText: '完整岗位描述',
+      preview: null,
+      previewSignature: '',
+    })
+  })
+
+  test('drops a cached preview with object summaries', () => {
+    expect(sanitizeJobPrepDraft({
+      jdText: '完整岗位描述',
+      previewSignature: 'old-signature',
+      preview: {
+        role_summary: { overview: '高级 Java 岗位' },
+        resume_alignment: { fit_assessment: { conclusion: '基本匹配' } },
+      },
+    })).toMatchObject({ preview: null, previewSignature: '' })
+  })
+})


### PR DESCRIPTION
## Motivation

OpenAI-compatible models can return semantically valid JD analysis JSON with object-shaped summary and list entries. The current renderer assumes strings, causing `Objects are not valid as a React child` and leaving an incompatible preview cached in localStorage. Bun's default 10-second idle timeout also aborts legitimate long-running model requests.

## Changes

- Normalize object and alias variants in JD preview responses into the frontend contract.
- Discard only incompatible cached previews while preserving company, position, and JD input.
- Configure Bun's server idle timeout to 255 seconds for long model requests.
- Add regression coverage for the observed provider response shapes, stale cache, and server timeout configuration.

## Verification

- `bun test apps packages tests-ts`: 159 passed, 0 failed
- `bun run typecheck`
- `bun run typecheck:node`
- `bun run check:boundaries`
- `bun run check:frontend`
- `bun run build:api`
- `bun run --cwd apps/desktop build`
- `bun scripts/build-desktop-backend.ts`

`bun run check` reaches the final desktop packaging step, where the local environment hits an existing `electron-builder` CommonJS / `@noble/hashes` ESM compatibility error unrelated to this diff.

## Compatibility

No API schema changes. Existing string-shaped model responses remain unchanged; object-shaped variants are normalized before reaching the frontend.