### PR TITLE
feat(provider): add Atlas Cloud LLM preset

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,7 +4,7 @@
 
 ## LLM
 
-填写 OpenAI-compatible API Base、API Key、Model、API 兼容模式和 Temperature。普通平台选择“通用 OpenAI 兼容”；DeepSeek V4 选择“DeepSeek V4”。先点击测试，确认账号确实能调用该模型，再保存。训练、面试、复盘、个人 Agent 和 Copilot 都使用这套生效中的配置。DeepSeek 模式只会对结构化请求附加 JSON 输出和低推理参数，普通文本请求及其他平台不会收到这些字段。
+填写 OpenAI-compatible API Base、API Key、Model、API 兼容模式和 Temperature。使用 Atlas Cloud 时可点击 API Base 旁的预设按钮，自动填入 `https://api.atlascloud.ai/v1` 并使用通用 OpenAI 兼容模式；模型名仍需填写当前 Atlas Cloud 账号实际可调用的模型 ID。普通平台选择“通用 OpenAI 兼容”；DeepSeek V4 选择“DeepSeek V4”。先点击测试，确认账号确实能调用该模型，再保存。训练、面试、复盘、个人 Agent 和 Copilot 都使用这套生效中的配置。DeepSeek 模式只会对结构化请求附加 JSON 输出和低推理参数，普通文本请求及其他平台不会收到这些字段。
 
 ## Embedding
 

--- a/frontend/src/lib/llmProviderPresets.js
+++ b/frontend/src/lib/llmProviderPresets.js
@@ -1,0 +1,8 @@
+export const ATLAS_CLOUD_LLM_API_BASE = "https://api.atlascloud.ai/v1";
+
+export function atlasCloudLlmPreset() {
+  return {
+    apiBase: ATLAS_CLOUD_LLM_API_BASE,
+    compatibility: "generic",
+  };
+}

--- a/frontend/src/lib/llmProviderPresets.test.js
+++ b/frontend/src/lib/llmProviderPresets.test.js
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ATLAS_CLOUD_LLM_API_BASE,
+  atlasCloudLlmPreset,
+} from "./llmProviderPresets.js";
+
+test("configures Atlas Cloud through the generic OpenAI-compatible driver", () => {
+  assert.deepEqual(atlasCloudLlmPreset(), {
+    apiBase: ATLAS_CLOUD_LLM_API_BASE,
+    compatibility: "generic",
+  });
+  assert.equal(ATLAS_CLOUD_LLM_API_BASE, "https://api.atlascloud.ai/v1");
+});

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -7,13 +7,14 @@ import {
   testLLMConnection,
   testEmbeddingConnection,
 } from "../api/interview";
-import { Loader2, Server, Boxes, ArrowRight, ArrowLeft, Eye, EyeOff, LogOut } from "lucide-react";
+import { Loader2, Server, Boxes, ArrowRight, ArrowLeft, Eye, EyeOff, LogOut, Cloud } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import Logo from "../components/Logo";
+import { atlasCloudLlmPreset } from "@/lib/llmProviderPresets";
 
 // 首登引导：每个用户都得带自己的 key,这里两步把 LLM + Embedding 配齐。
 // 其余可选服务(语音/搜索/录音上传)留到设置页按需填。
@@ -133,6 +134,12 @@ export default function Onboarding() {
     { n: 2, label: "Embedding", icon: Boxes },
   ];
 
+  function useAtlasCloud() {
+    const preset = atlasCloudLlmPreset();
+    setApiBase(preset.apiBase);
+    setCompatibility(preset.compatibility);
+  }
+
   return (
     <div className="min-h-screen bg-bg flex items-center justify-center px-4 py-10 relative">
       <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[500px] h-[300px] bg-gradient-to-b from-primary/8 to-transparent rounded-full blur-[80px] pointer-events-none" />
@@ -183,7 +190,13 @@ export default function Onboarding() {
                   填你自己的 LLM(OpenAI 兼容接口)。没有的话,ModelScope 的 <span className="text-text">ZhipuAI/GLM-5</span> 有免费额度可先跑通。
                 </div>
                 <div className="space-y-2">
-                  <Label className={labelClass}>API Base URL</Label>
+                  <div className="flex items-center justify-between gap-3">
+                    <Label className={labelClass}>API Base URL</Label>
+                    <Button type="button" variant="outline" size="sm" className="h-8 gap-1.5" onClick={useAtlasCloud} title="使用 Atlas Cloud LLM API">
+                      <Cloud size={14} />
+                      Atlas Cloud
+                    </Button>
+                  </div>
                   <Input className={inputClass} placeholder="例：https://api-inference.modelscope.cn/v1" value={apiBase} onChange={(e) => setApiBase(e.target.value)} />
                 </div>
                 <div className="space-y-2">

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -19,6 +19,7 @@ import {
   KeyRound,
   Plug,
   XCircle,
+  Cloud,
 } from "lucide-react";
 import {
   getSettings,
@@ -41,6 +42,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { isDesktopApp } from "@/lib/desktop";
+import { atlasCloudLlmPreset } from "@/lib/llmProviderPresets";
 
 // 录音参数
 const VP_SAMPLE_RATE = 16000;
@@ -540,6 +542,12 @@ export default function Settings() {
     }
   };
 
+  const useAtlasCloud = () => {
+    const preset = atlasCloudLlmPreset();
+    setApiBase(preset.apiBase);
+    setCompatibility(preset.compatibility);
+  };
+
   const handleTestLLM = async () => {
     setLlmTest({ status: "testing" });
     try {
@@ -798,7 +806,21 @@ export default function Settings() {
 
             <div className={cn("grid gap-4 md:grid-cols-2", ownLlmDisabled && "opacity-60")}>
               <div className="space-y-2">
-                <Label className={labelClass}>API Base URL</Label>
+                <div className="flex items-center justify-between gap-3">
+                  <Label className={labelClass}>API Base URL</Label>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-8 gap-1.5"
+                    disabled={ownLlmDisabled}
+                    onClick={useAtlasCloud}
+                    title="使用 Atlas Cloud LLM API"
+                  >
+                    <Cloud size={14} />
+                    Atlas Cloud
+                  </Button>
+                </div>
                 <Input
                   name="llm-api-base"
                   className={inputClass}


### PR DESCRIPTION
## Summary

- add an Atlas Cloud preset beside the LLM API Base field in onboarding and settings
- configure the preset through the existing generic OpenAI-compatible driver without changing the default provider path
- document the Atlas Cloud endpoint and add a focused preset test

## Validation

- `bun run --cwd frontend test`
- `bun run --cwd frontend typecheck`
- `bun run --cwd frontend lint` (passes with existing warnings)
- `bun run --cwd frontend build`
- `git diff --check`
- verified the onboarding layout at 1440x900

## Compatibility

Atlas Cloud remains opt-in. Existing saved provider settings and the default generic provider behavior are unchanged.